### PR TITLE
2 feature request turn off summary - only transcribe

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
 	"id": "scribe",
 	"name": "Scribe",
-	"version": "1.0.4",
+	"version": "1.0.5",
 	"minAppVersion": "0.15.0",
 	"description": "Record voice notes, Fill in lost thoughts, Transcribe the audio, Summarize & Visualize the text - All in one clip",
 	"author": "Mike Alicea",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "obsidian-scribe-plugin",
-	"version": "1.0.4",
+	"version": "1.0.5",
 	"description": "An Obsidian plugin for recording voice notes, transcribing the audio, and summarizing the text - All in one",
 	"main": "build/main.js",
 	"scripts": {

--- a/src/index.ts
+++ b/src/index.ts
@@ -126,7 +126,7 @@ export default class ScribePlugin extends Plugin {
     }
   }
 
-  async scribe(scribeOptions: ScribeOptions) {
+  async scribe(scribeOptions: ScribeOptions = {}) {
     try {
       const baseFileName = createBaseFileName();
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -46,6 +46,11 @@ const DEFAULT_STATE: ScribeState = {
   openAiClient: null,
 };
 
+export interface ScribeOptions {
+  isAppendToActiveFile?: boolean;
+  isOnlyTranscribeActive?: boolean;
+}
+
 export default class ScribePlugin extends Plugin {
   settings: ScribePluginSettings = DEFAULT_SETTINGS;
   state: ScribeState = DEFAULT_STATE;
@@ -121,10 +126,7 @@ export default class ScribePlugin extends Plugin {
     }
   }
 
-  async scribe(
-    isAppendToActiveFile?: boolean,
-    isOnlyTranscribeActive?: boolean,
-  ) {
+  async scribe(scribeOptions: ScribeOptions) {
     try {
       const baseFileName = createBaseFileName();
 
@@ -135,8 +137,7 @@ export default class ScribePlugin extends Plugin {
         baseNoteAndAudioFileName: baseFileName,
         audioRecordingFile: recordingFile,
         audioRecordingBuffer: recordingBuffer,
-        isAppendToActiveFile,
-        isOnlyTranscribeActive,
+        scribeOptions: scribeOptions,
       });
     } catch (error) {
       new Notice(`Scribe: Something went wrong ${error.toString()}`);
@@ -229,15 +230,14 @@ export default class ScribePlugin extends Plugin {
     baseNoteAndAudioFileName,
     audioRecordingFile,
     audioRecordingBuffer,
-    isAppendToActiveFile,
-    isOnlyTranscribeActive,
+    scribeOptions = {},
   }: {
     baseNoteAndAudioFileName: string;
     audioRecordingFile: TFile;
     audioRecordingBuffer: ArrayBuffer;
-    isAppendToActiveFile?: boolean;
-    isOnlyTranscribeActive?: boolean;
+    scribeOptions?: ScribeOptions;
   }) {
+    const { isAppendToActiveFile, isOnlyTranscribeActive } = scribeOptions;
     const scribeNoteFilename = `scribe-${baseNoteAndAudioFileName}`;
 
     let note = isAppendToActiveFile

--- a/src/index.ts
+++ b/src/index.ts
@@ -121,7 +121,10 @@ export default class ScribePlugin extends Plugin {
     }
   }
 
-  async scribe(isAppendToActiveFile?: boolean) {
+  async scribe(
+    isAppendToActiveFile?: boolean,
+    isOnlyTranscribeActive?: boolean,
+  ) {
     try {
       const baseFileName = createBaseFileName();
 
@@ -133,6 +136,7 @@ export default class ScribePlugin extends Plugin {
         audioRecordingFile: recordingFile,
         audioRecordingBuffer: recordingBuffer,
         isAppendToActiveFile,
+        isOnlyTranscribeActive,
       });
     } catch (error) {
       new Notice(`Scribe: Something went wrong ${error.toString()}`);
@@ -226,11 +230,13 @@ export default class ScribePlugin extends Plugin {
     audioRecordingFile,
     audioRecordingBuffer,
     isAppendToActiveFile,
+    isOnlyTranscribeActive,
   }: {
     baseNoteAndAudioFileName: string;
     audioRecordingFile: TFile;
     audioRecordingBuffer: ArrayBuffer;
     isAppendToActiveFile?: boolean;
+    isOnlyTranscribeActive?: boolean;
   }) {
     const scribeNoteFilename = `scribe-${baseNoteAndAudioFileName}`;
 
@@ -254,7 +260,11 @@ export default class ScribePlugin extends Plugin {
     this.app.workspace.openLinkText(note?.path, currentPath, true);
 
     const transcript = await this.handleTranscription(audioRecordingBuffer);
-    await addTranscriptToNote(this, note, transcript);
+    await addTranscriptToNote(this, note, transcript, isOnlyTranscribeActive);
+
+    if (isOnlyTranscribeActive) {
+      return;
+    }
 
     const llmSummary = await this.handleTranscriptSummary(transcript);
     await addSummaryToNote(this, note, llmSummary);

--- a/src/modal/components/ModalRecordingOptions.tsx
+++ b/src/modal/components/ModalRecordingOptions.tsx
@@ -1,12 +1,23 @@
 export function ModalRecordingOptions({
   isAppendToActiveFile,
   setIsAppendToActiveFile,
+  isOnlyTranscribeActive,
+  setIsOnlyTranscribeActive,
 }: {
   isAppendToActiveFile: boolean;
   setIsAppendToActiveFile: (value: boolean) => void;
+  isOnlyTranscribeActive: boolean;
+  setIsOnlyTranscribeActive: (value: boolean) => void;
 }) {
-  const handleCheckboxChange = (event: React.ChangeEvent<HTMLInputElement>) => {
+  const handleChangeIsAppendToActiveFile = (
+    event: React.ChangeEvent<HTMLInputElement>,
+  ) => {
     setIsAppendToActiveFile(event.target.checked);
+  };
+  const handleChangeIsOnlyTranscribeActive = (
+    event: React.ChangeEvent<HTMLInputElement>,
+  ) => {
+    setIsOnlyTranscribeActive(event.target.checked);
   };
 
   return (
@@ -15,9 +26,18 @@ export function ModalRecordingOptions({
         <input
           type="checkbox"
           checked={isAppendToActiveFile}
-          onChange={handleCheckboxChange}
+          onChange={handleChangeIsAppendToActiveFile}
         />
         Append to active file
+      </label>
+
+      <label>
+        <input
+          type="checkbox"
+          checked={isOnlyTranscribeActive}
+          onChange={handleChangeIsOnlyTranscribeActive}
+        />
+        Only transcribe recording
       </label>
     </div>
   );

--- a/src/modal/components/ModalRecordingOptions.tsx
+++ b/src/modal/components/ModalRecordingOptions.tsx
@@ -1,24 +1,26 @@
+import type { ScribeOptions } from 'src';
+
 export function ModalRecordingOptions({
-  isAppendToActiveFile,
-  setIsAppendToActiveFile,
-  isOnlyTranscribeActive,
-  setIsOnlyTranscribeActive,
+  options,
+  setOptions,
 }: {
-  isAppendToActiveFile: boolean;
-  setIsAppendToActiveFile: (value: boolean) => void;
-  isOnlyTranscribeActive: boolean;
-  setIsOnlyTranscribeActive: (value: boolean) => void;
+  options: ScribeOptions;
+  setOptions: React.Dispatch<ScribeOptions>;
 }) {
   const handleChangeIsAppendToActiveFile = (
     event: React.ChangeEvent<HTMLInputElement>,
   ) => {
-    setIsAppendToActiveFile(event.target.checked);
+    // setIsAppendToActiveFile(event.target.checked);
+    setOptions({ ...options, isAppendToActiveFile: event.target.checked });
   };
   const handleChangeIsOnlyTranscribeActive = (
     event: React.ChangeEvent<HTMLInputElement>,
   ) => {
-    setIsOnlyTranscribeActive(event.target.checked);
+    setOptions({ ...options, isOnlyTranscribeActive: event.target.checked });
+    // setIsOnlyTranscribeActive(event.target.checked);
   };
+
+  const { isAppendToActiveFile, isOnlyTranscribeActive } = options;
 
   return (
     <div className="scribe-recording-options">

--- a/src/modal/scribeControlsModal.tsx
+++ b/src/modal/scribeControlsModal.tsx
@@ -1,6 +1,7 @@
 import { createRoot, type Root } from 'react-dom/client';
 import { Modal } from 'obsidian';
 import type ScribePlugin from 'src';
+import type { ScribeOptions } from 'src';
 import { useState } from 'react';
 import { ModalSettings } from './components/ModalSettings';
 import { ModalRecordingTimer } from './components/ModalRecordingTimer';
@@ -53,8 +54,12 @@ const ScribeModal: React.FC<{ plugin: ScribePlugin }> = ({ plugin }) => {
   const [recordingStartTimeMs, setRecordingStartTimeMs] = useState<
     number | null
   >(null);
-  const [isAppendToActiveFile, setIsAppendToActiveFile] = useState(false);
-  const [isOnlyTranscribeActive, setIsOnlyTranscribeActive] = useState(false);
+  const [scribeOptions, setScribeOptions] = useState<ScribeOptions>({
+    isAppendToActiveFile: false,
+    isOnlyTranscribeActive: false,
+  });
+
+  const { isAppendToActiveFile, isOnlyTranscribeActive } = scribeOptions;
 
   const hasOpenAiApiKey = Boolean(plugin.settings.openAiApiKey);
 
@@ -85,7 +90,7 @@ const ScribeModal: React.FC<{ plugin: ScribePlugin }> = ({ plugin }) => {
     setIsScribing(true);
     setRecordingStartTimeMs(null);
     setRecordingState('inactive');
-    await plugin.scribe(isAppendToActiveFile, isOnlyTranscribeActive);
+    await plugin.scribe({ isAppendToActiveFile, isOnlyTranscribeActive });
     setIsPaused(false);
     setIsActive(false);
     setIsScribing(false);
@@ -140,10 +145,8 @@ const ScribeModal: React.FC<{ plugin: ScribePlugin }> = ({ plugin }) => {
           Settings
         </button>
         <ModalRecordingOptions
-          isAppendToActiveFile={isAppendToActiveFile}
-          setIsAppendToActiveFile={setIsAppendToActiveFile}
-          isOnlyTranscribeActive={isOnlyTranscribeActive}
-          setIsOnlyTranscribeActive={setIsOnlyTranscribeActive}
+          options={scribeOptions}
+          setOptions={setScribeOptions}
         />
       </div>
 

--- a/src/modal/scribeControlsModal.tsx
+++ b/src/modal/scribeControlsModal.tsx
@@ -54,6 +54,7 @@ const ScribeModal: React.FC<{ plugin: ScribePlugin }> = ({ plugin }) => {
     number | null
   >(null);
   const [isAppendToActiveFile, setIsAppendToActiveFile] = useState(false);
+  const [isOnlyTranscribeActive, setIsOnlyTranscribeActive] = useState(false);
 
   const hasOpenAiApiKey = Boolean(plugin.settings.openAiApiKey);
 
@@ -84,7 +85,7 @@ const ScribeModal: React.FC<{ plugin: ScribePlugin }> = ({ plugin }) => {
     setIsScribing(true);
     setRecordingStartTimeMs(null);
     setRecordingState('inactive');
-    await plugin.scribe(isAppendToActiveFile);
+    await plugin.scribe(isAppendToActiveFile, isOnlyTranscribeActive);
     setIsPaused(false);
     setIsActive(false);
     setIsScribing(false);
@@ -141,6 +142,8 @@ const ScribeModal: React.FC<{ plugin: ScribePlugin }> = ({ plugin }) => {
         <ModalRecordingOptions
           isAppendToActiveFile={isAppendToActiveFile}
           setIsAppendToActiveFile={setIsAppendToActiveFile}
+          isOnlyTranscribeActive={isOnlyTranscribeActive}
+          setIsOnlyTranscribeActive={setIsOnlyTranscribeActive}
         />
       </div>
 

--- a/src/styles.css
+++ b/src/styles.css
@@ -144,3 +144,14 @@ If your plugin does not need CSS, delete this file.
   align-items: center;
   justify-content: space-between;
 }
+
+.scribe-recording-options {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  justify-content: space-between;
+
+  label {
+    margin-bottom: .5em;
+  }
+}

--- a/src/util/fileUtils.ts
+++ b/src/util/fileUtils.ts
@@ -90,9 +90,12 @@ export async function addTranscriptToNote(
   plugin: ScribePlugin,
   noteFile: TFile,
   transcript: string,
+  isOnlyTranscribeActive?: boolean,
 ) {
   try {
-    const textToAdd = `${transcript}
+    const textToAdd = isOnlyTranscribeActive
+      ? `${transcript}`
+      : `${transcript}
 ${SUMMARY_IN_PROGRESS_HEADER}`;
 
     await plugin.app.vault.process(noteFile, (data) => {


### PR DESCRIPTION
Adds the feature to enable the user to only transcribe the recording  
This removes the summary and everything related to the LLM - it also keeps the pure timestamp naming convention. 

<img width="505" alt="image" src="https://github.com/user-attachments/assets/7886673c-d373-444e-a727-88d5ef85dfcb" />
