### PR TITLE
Overhauls the Filename Prefix Settings

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "id": "scribe",
   "name": "Scribe",
-  "version": "1.1.1",
+  "version": "1.1.2",
   "minAppVersion": "0.15.0",
   "description": "Record voice notes, Fill in lost thoughts, Transcribe the audio, Summarize & Visualize the text - All in one clip",
   "author": "Mike Alicea",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,18 +1,19 @@
 {
   "name": "obsidian-scribe-plugin",
-  "version": "1.0.0",
+  "version": "1.1.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "obsidian-scribe-plugin",
-      "version": "1.0.0",
+      "version": "1.1.1",
       "license": "MIT",
       "dependencies": {
         "@langchain/core": "^0.3.14",
         "@langchain/openai": "^0.3.11",
         "assemblyai": "^4.8.0",
         "langchain": "^0.3.3",
+        "mini-debounce": "^1.0.8",
         "openai": "^4.68.3",
         "react": "^18.3.1",
         "react-dom": "^18.3.1",
@@ -1157,6 +1158,12 @@
       "engines": {
         "node": ">= 0.6"
       }
+    },
+    "node_modules/mini-debounce": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/mini-debounce/-/mini-debounce-1.0.8.tgz",
+      "integrity": "sha512-EqUsV34zuw2N9UHjRl1bwaDiLe1d/P8AemSp/EbDjOsZ7gB+z+7F9wcJWqfU3QpPnHD1oKGe2n6Fw90QsLkBkA==",
+      "license": "MIT"
     },
     "node_modules/moment": {
       "version": "2.29.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "obsidian-scribe-plugin",
-  "version": "1.1.1",
+  "version": "1.1.2",
   "description": "An Obsidian plugin for recording voice notes, transcribing the audio, and summarizing the text - All in one",
   "main": "build/main.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "@langchain/openai": "^0.3.11",
     "assemblyai": "^4.8.0",
     "langchain": "^0.3.3",
+    "mini-debounce": "^1.0.8",
     "openai": "^4.68.3",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",

--- a/src/index.ts
+++ b/src/index.ts
@@ -98,6 +98,7 @@ export default class ScribePlugin extends Plugin {
   }
 
   async saveSettings() {
+    new Notice('Scribe: ✅ Settings saved');
     await this.saveData(this.settings);
   }
 

--- a/src/settings/components/FileNameSettings.tsx
+++ b/src/settings/components/FileNameSettings.tsx
@@ -1,0 +1,94 @@
+import { useState } from 'react';
+import type ScribePlugin from 'src/index';
+
+import { formatFilenamePrefix } from 'src/util/filenameUtils';
+import { SettingsItem } from './SettingsItem';
+
+export const FileNameSettings: React.FC<{
+  plugin: ScribePlugin;
+  saveSettings: () => void;
+}> = ({ plugin, saveSettings }) => {
+  const [noteFilenamePrefix, setNoteFilenamePrefix] = useState(
+    plugin.settings.noteFilenamePrefix,
+  );
+  const [recordingFilenamePrefix, setRecordingFilenamePrefix] = useState(
+    plugin.settings.recordingFilenamePrefix,
+  );
+  const [dateFilenameFormat, setDateFilenameFormat] = useState(
+    plugin.settings.dateFilenameFormat,
+  );
+  const isDateInPrefix =
+    (noteFilenamePrefix || '').includes('{{date}}') ||
+    (recordingFilenamePrefix || '').includes('{{date}}');
+  return (
+    <div>
+      <h2>File name properties</h2>
+      <SettingsItem
+        name="Transcript filename prefix"
+        description="This will be the prefix of the note filename, use {{date}} to include the date"
+        control={
+          <input
+            type="text"
+            placeholder="scribe-"
+            value={noteFilenamePrefix}
+            onChange={(e) => {
+              setNoteFilenamePrefix(e.target.value);
+              plugin.settings.noteFilenamePrefix = e.target.value;
+              saveSettings();
+            }}
+          />
+        }
+      />
+      <SettingsItem
+        name="Audio recording filename prefix"
+        description="This will be the prefix of the audio recording filename, use {{date}} to include the date"
+        control={
+          <input
+            type="text"
+            placeholder="scribe-"
+            value={recordingFilenamePrefix}
+            onChange={(e) => {
+              setRecordingFilenamePrefix(e.target.value);
+              plugin.settings.recordingFilenamePrefix = e.target.value;
+              saveSettings();
+            }}
+          />
+        }
+      />
+      <SettingsItem
+        name="Date format"
+        description="This will only be used if {{date}} is in the transcript or audio recording filename prefix above."
+        control={
+          <div>
+            <input
+              type="text"
+              placeholder="YYYY-MM-DD"
+              disabled={!isDateInPrefix}
+              value={dateFilenameFormat}
+              onChange={(e) => {
+                setDateFilenameFormat(e.target.value);
+                plugin.settings.dateFilenameFormat = e.target.value;
+                saveSettings();
+              }}
+            />
+          </div>
+        }
+      />
+      {isDateInPrefix && (
+        <div>
+          <p>
+            {formatFilenamePrefix(`${noteFilenamePrefix}`, dateFilenameFormat)}
+            filename
+          </p>
+          <p>
+            {formatFilenamePrefix(
+              `${recordingFilenamePrefix}`,
+              dateFilenameFormat,
+            )}
+            filename
+          </p>
+        </div>
+      )}
+    </div>
+  );
+};

--- a/src/settings/components/SettingsItem.tsx
+++ b/src/settings/components/SettingsItem.tsx
@@ -1,0 +1,15 @@
+export const SettingsItem: React.FC<{
+  name: string;
+  description: string;
+  control: React.ReactNode;
+}> = ({ name, description, control }) => {
+  return (
+    <div className="setting-item">
+      <div className="setting-item-info">
+        <div className="setting-item-name">{name}</div>
+        <div className="setting-item-description">{description}</div>
+      </div>
+      <div className="setting-item-control">{control}</div>
+    </div>
+  );
+};

--- a/src/settings/settings.tsx
+++ b/src/settings/settings.tsx
@@ -1,5 +1,10 @@
 import { type App, Notice, PluginSettingTab, Setting, moment } from 'obsidian';
+import { createRoot, type Root } from 'react-dom/client';
+import { useEffect, useMemo, useRef, useState } from 'react';
+import { debounce } from 'mini-debounce';
+
 import type ScribePlugin from 'src';
+
 import { formatFilenamePrefix } from 'src/util/filenameUtils';
 import { LLM_MODELS } from 'src/util/openAiUtils';
 
@@ -41,6 +46,7 @@ export async function handleSettingsTab(plugin: ScribePlugin) {
 
 export class ScribeSettingsTab extends PluginSettingTab {
   plugin: ScribePlugin;
+  reactRoot: Root | null;
 
   constructor(app: App, plugin: ScribePlugin) {
     super(app, plugin);
@@ -178,109 +184,12 @@ export class ScribeSettingsTab extends PluginSettingTab {
         component.setValue(this.plugin.settings.transcriptPlatform);
       });
 
-    containerEl.createEl('h2', { text: 'File name properties' });
-    containerEl.createEl('sub', {
-      text: 'These settings must be saved via the button for validation purposes',
+    const reactTestWrapper = containerEl.createDiv({
+      cls: 'scribe-settings-react',
     });
 
-    const isDateInPrefix = () =>
-      this.plugin.settings.noteFilenamePrefix.includes('{{date}}') ||
-      this.plugin.settings.recordingFilenamePrefix.includes('{{date}}');
-
-    new Setting(containerEl)
-      .setName('Transcript filename prefix')
-      .setDesc(
-        'This will be the prefix of the note filename, use {{date}} to include the date',
-      )
-      .addText((text) => {
-        text.setPlaceholder('scribe-');
-        text.onChange((value) => {
-          this.plugin.settings.noteFilenamePrefix = value;
-
-          dateInput.setDisabled(!isDateInPrefix());
-        });
-
-        text.setValue(this.plugin.settings.noteFilenamePrefix);
-      });
-
-    new Setting(containerEl)
-      .setName('Audio recording filename prefix')
-      .setDesc(
-        'This will be the prefix of the audio recording filename, use {{date}} to include the date',
-      )
-      .addText((text) => {
-        text.setPlaceholder('scribe-');
-        text.onChange((value) => {
-          this.plugin.settings.recordingFilenamePrefix = value;
-          dateInput.setDisabled(!isDateInPrefix());
-        });
-
-        text.setValue(this.plugin.settings.recordingFilenamePrefix);
-      });
-
-    const dateInput = new Setting(containerEl)
-      .setName('Date format')
-      .setDesc(
-        'This will only be used if {{date}} is in the transcript or audio recording filename prefix above.',
-      )
-      .addText((text) => {
-        text.setDisabled(!isDateInPrefix());
-        text.setPlaceholder('YYYY-MM-DD');
-        text.onChange((value) => {
-          this.plugin.settings.dateFilenameFormat = value;
-          console.log(value);
-          try {
-            new Notice(
-              `📆 Format: ${formatFilenamePrefix(
-                'some-prefix-{{date}}',
-                value,
-              )}`,
-            );
-          } catch (error) {
-            console.error('Invalid date format', error);
-            new Notice(`Invalid date format: ${value}`);
-          }
-        });
-
-        text.setValue(this.plugin.settings.dateFilenameFormat);
-      });
-
-    new Setting(containerEl).addButton((button) => {
-      button.setButtonText('Save settings');
-      button.onClick(async () => {
-        if (!this.plugin.settings.noteFilenamePrefix) {
-          new Notice(
-            '⚠️ You must provide a note filename prefix, setting to default',
-          );
-          this.plugin.settings.noteFilenamePrefix =
-            DEFAULT_SETTINGS.noteFilenamePrefix;
-        }
-
-        if (!this.plugin.settings.recordingFilenamePrefix) {
-          new Notice(
-            '⚠️ You must provide a recording filename prefix, setting to default',
-          );
-          this.plugin.settings.recordingFilenamePrefix =
-            DEFAULT_SETTINGS.recordingFilenamePrefix;
-        }
-
-        if (
-          this.plugin.settings.noteFilenamePrefix.includes('{{date}}') &&
-          !this.plugin.settings.dateFilenameFormat
-        ) {
-          new Notice('⚠️ You must provide a date format, setting to default');
-          this.plugin.settings.dateFilenameFormat =
-            DEFAULT_SETTINGS.dateFilenameFormat;
-        }
-
-        this.saveSettings();
-        this.display();
-      });
-    });
-
-    containerEl.createEl('sub', {
-      text: 'This functionality will improve in future versions',
-    });
+    this.reactRoot = createRoot(reactTestWrapper);
+    this.reactRoot.render(<ScribeSettings plugin={this.plugin} />);
 
     new Setting(containerEl).addButton((button) => {
       button.setButtonText('Reset to default');
@@ -302,3 +211,128 @@ export class ScribeSettingsTab extends PluginSettingTab {
     new Notice('Scribe: ✅ Settings saved');
   }
 }
+
+const ScribeSettings: React.FC<{ plugin: ScribePlugin }> = ({ plugin }) => {
+  const [noteFilenamePrefix, setNoteFilenamePrefix] = useState(
+    plugin.settings.noteFilenamePrefix,
+  );
+  const [recordingFilenamePrefix, setRecordingFilenamePrefix] = useState(
+    plugin.settings.recordingFilenamePrefix,
+  );
+  const [dateFilenameFormat, setDateFilenameFormat] = useState(
+    plugin.settings.dateFilenameFormat,
+  );
+  const isDateInPrefix =
+    (noteFilenamePrefix || '').includes('{{date}}') ||
+    (recordingFilenamePrefix || '').includes('{{date}}');
+
+  const savedNotif = useDebounce(() => {
+    plugin.saveSettings();
+  }, 500);
+
+  return (
+    <div>
+      <h2>File name properties</h2>
+      <SettingsItem
+        name="Transcript filename prefix"
+        description="This will be the prefix of the note filename, use {{date}} to include the date"
+        control={
+          <input
+            type="text"
+            placeholder="scribe-"
+            value={noteFilenamePrefix}
+            onChange={(e) => {
+              setNoteFilenamePrefix(e.target.value);
+              plugin.settings.noteFilenamePrefix = e.target.value;
+              savedNotif();
+            }}
+          />
+        }
+      />
+      <SettingsItem
+        name="Audio recording filename prefix"
+        description="This will be the prefix of the audio recording filename, use {{date}} to include the date"
+        control={
+          <input
+            type="text"
+            placeholder="scribe-"
+            value={recordingFilenamePrefix}
+            onChange={(e) => {
+              setRecordingFilenamePrefix(e.target.value);
+              plugin.settings.recordingFilenamePrefix = e.target.value;
+              savedNotif();
+            }}
+          />
+        }
+      />
+      <SettingsItem
+        name="Date format"
+        description="This will only be used if {{date}} is in the transcript or audio recording filename prefix above."
+        control={
+          <div>
+            <input
+              type="text"
+              placeholder="YYYY-MM-DD"
+              disabled={!isDateInPrefix}
+              value={dateFilenameFormat}
+              onChange={(e) => {
+                setDateFilenameFormat(e.target.value);
+                plugin.settings.dateFilenameFormat = e.target.value;
+                savedNotif();
+              }}
+            />
+          </div>
+        }
+      />
+      {isDateInPrefix && (
+        <div>
+          <p>
+            {formatFilenamePrefix(`${noteFilenamePrefix}`, dateFilenameFormat)}
+            filename
+          </p>
+          <p>
+            {formatFilenamePrefix(
+              `${recordingFilenamePrefix}`,
+              dateFilenameFormat,
+            )}
+            filename
+          </p>
+        </div>
+      )}
+    </div>
+  );
+};
+
+const SettingsItem: React.FC<{
+  name: string;
+  description: string;
+  control: React.ReactNode;
+}> = ({ name, description, control }) => {
+  return (
+    <div className="setting-item">
+      <div className="setting-item-info">
+        <div className="setting-item-name">{name}</div>
+        <div className="setting-item-description">{description}</div>
+      </div>
+      <div className="setting-item-control">{control}</div>
+    </div>
+  );
+};
+
+const useDebounce = (callback: () => void, timeMs: number): (() => void) => {
+  const ref = useRef<() => void>();
+
+  useEffect(() => {
+    ref.current = callback;
+  }, [callback]);
+
+  const debouncedCallback = useMemo(() => {
+    const func = () => {
+      ref.current?.();
+    };
+
+    return debounce(func, timeMs);
+  }, [timeMs]);
+
+  return debouncedCallback;
+};

--- a/src/settings/settings.tsx
+++ b/src/settings/settings.tsx
@@ -212,13 +212,13 @@ export class ScribeSettingsTab extends PluginSettingTab {
 }
 
 const ScribeSettings: React.FC<{ plugin: ScribePlugin }> = ({ plugin }) => {
-  const savedNotif = useDebounce(() => {
+  const debouncedSaveSettings = useDebounce(() => {
     plugin.saveSettings();
   }, 700);
 
   return (
     <div>
-      <FileNameSettings plugin={plugin} saveSettings={savedNotif} />
+      <FileNameSettings plugin={plugin} saveSettings={debouncedSaveSettings} />
     </div>
   );
 };

--- a/src/util/useDebounce.tsx
+++ b/src/util/useDebounce.tsx
@@ -1,0 +1,23 @@
+import { debounce } from 'mini-debounce';
+import { useEffect, useMemo, useRef } from 'react';
+
+export const useDebounce = (
+  callback: () => void,
+  timeMs: number,
+): (() => void) => {
+  const ref = useRef<() => void>();
+
+  useEffect(() => {
+    ref.current = callback;
+  }, [callback]);
+
+  const debouncedCallback = useMemo(() => {
+    const func = () => {
+      ref.current?.();
+    };
+
+    return debounce(func, timeMs);
+  }, [timeMs]);
+
+  return debouncedCallback;
+};

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -14,5 +14,9 @@
     "strictNullChecks": true,
     "lib": ["DOM", "ES5", "ES6", "ES7"]
   },
-  "include": ["**/*.ts", "src/modal/scribeControlsModal.tsx"]
+  "include": [
+    "**/*.ts",
+    "src/modal/scribeControlsModal.tsx",
+    "src/settings/settings.tsx"
+  ]
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -14,9 +14,5 @@
     "strictNullChecks": true,
     "lib": ["DOM", "ES5", "ES6", "ES7"]
   },
-  "include": [
-    "**/*.ts",
-    "src/modal/scribeControlsModal.tsx",
-    "src/settings/settings.tsx"
-  ]
+  "include": ["src/*.ts", "src/*.tsx", "src/**/*.ts", "src/**/*.tsx"]
 }


### PR DESCRIPTION
# Overhauls the Filename Prefix Settings
This has 2 functions
1. Makes it so the user doesn't have to click the "save settings" button (thank god)
2. Enables us to visibly see the prefix settings in real time
3. Sets us up for https://github.com/Mikodin/obsidian-scribe/issues/11 & https://github.com/Mikodin/obsidian-scribe/issues/4 by creating the first React components for settings.  This is the basework for creating templates through the settings by giving me a nice workspace