### PR TITLE
25 transcription broken en us error

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "id": "scribe",
   "name": "Scribe",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "minAppVersion": "0.15.0",
   "description": "Record, transcribe, and transform voice notes into structured insights. Leverage Whisper or AssemblyAI and ChatGPT to fill in gaps, generate summaries, and visualize ideas — all seamlessly integrated within Obsidian.",
   "author": "Mike Alicea",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "obsidian-scribe-plugin",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "description": "An Obsidian plugin for recording voice notes, transcribing the audio, and summarizing the text - All in one",
   "main": "build/main.js",
   "scripts": {

--- a/src/util/consts.ts
+++ b/src/util/consts.ts
@@ -7,9 +7,6 @@ export enum RECORDING_STATUS {
 export enum LanguageOptions {
   auto = 'auto',
   en = 'en',
-  en_au = 'en_au',
-  en_uk = 'en_uk',
-  en_us = 'en_us',
   es = 'es',
   fr = 'fr',
   de = 'de',
@@ -33,9 +30,6 @@ export type OutputLanguageOptions = Exclude<LanguageOptions, 'auto'>;
 export const LanguageDisplayNames: { [key in LanguageOptions]: string } = {
   [LanguageOptions.auto]: 'Auto Detect',
   [LanguageOptions.en]: 'English',
-  [LanguageOptions.en_au]: 'English (Australia)',
-  [LanguageOptions.en_uk]: 'English (UK)',
-  [LanguageOptions.en_us]: 'English (US)',
   [LanguageOptions.es]: 'Spanish',
   [LanguageOptions.fr]: 'French',
   [LanguageOptions.de]: 'German',


### PR DESCRIPTION
Fixes broken en variants (UK & AUS, etc) and just uses `en` as the language code