### PR TITLE
35 option to remove the created by yaml

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "id": "scribe",
   "name": "Scribe",
-  "version": "2.0.3",
+  "version": "2.0.4",
   "minAppVersion": "0.15.0",
   "description": "Record, transcribe, and transform voice notes into structured insights. Leverage Whisper or AssemblyAI and ChatGPT to fill in gaps, generate summaries, and visualize ideas — all seamlessly integrated within Obsidian.",
   "author": "Mike Alicea",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "obsidian-scribe-plugin",
-  "version": "2.0.3",
+  "version": "2.0.4",
   "description": "An Obsidian plugin for recording voice notes, transcribing the audio, and summarizing the text - All in one",
   "main": "build/main.js",
   "scripts": {

--- a/src/settings/settings.tsx
+++ b/src/settings/settings.tsx
@@ -36,6 +36,7 @@ export interface ScribePluginSettings {
   scribeOutputLanguage: OutputLanguageOptions;
   activeNoteTemplate: ScribeTemplate;
   noteTemplates: ScribeTemplate[];
+  isFrontMatterLinkToScribe: boolean;
 }
 
 export const DEFAULT_SETTINGS: ScribePluginSettings = {
@@ -55,6 +56,7 @@ export const DEFAULT_SETTINGS: ScribePluginSettings = {
   scribeOutputLanguage: LanguageOptions.en,
   activeNoteTemplate: DEFAULT_TEMPLATE,
   noteTemplates: [DEFAULT_TEMPLATE],
+  isFrontMatterLinkToScribe: true,
 };
 
 export async function handleSettingsTab(plugin: ScribePlugin) {
@@ -166,6 +168,19 @@ export class ScribeSettingsTab extends PluginSettingTab {
         toggle.setValue(this.plugin.settings.isOnlyTranscribeActive);
         toggle.onChange(async (value) => {
           this.plugin.settings.isOnlyTranscribeActive = value;
+          await this.saveSettings();
+        });
+      });
+
+    new Setting(containerEl)
+      .setName('Link to Scribe in "created_by" frontmatter')
+      .setDesc(
+        'If true, we will add a link to the Scribe in the frontmatter of the note.  This is useful for knowing which notes were created by Scribe.',
+      )
+      .addToggle((toggle) => {
+        toggle.setValue(this.plugin.settings.isFrontMatterLinkToScribe);
+        toggle.onChange(async (value) => {
+          this.plugin.settings.isFrontMatterLinkToScribe = value;
           await this.saveSettings();
         });
       });

--- a/src/util/fileUtils.ts
+++ b/src/util/fileUtils.ts
@@ -97,8 +97,11 @@ export async function setupFileFrontmatter(
         source: audioFile
           ? [...(frontMatter.source || []), `[[${audioFile.path}]]`]
           : frontMatter.source,
-        created_by: '[[Scribe]]',
       };
+
+      if (plugin.settings.isFrontMatterLinkToScribe) {
+        newFrontMatter.created_by = '[[Scribe]]';
+      }
 
       Object.assign(frontMatter, newFrontMatter);
     });


### PR DESCRIPTION
Enables users to disable `created_by` in the Front Matter of scribe notes
This adds the feature requested in #35 