### PR TITLE
33 obsidian create new file location isnt used correctly

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "id": "scribe",
   "name": "Scribe",
-  "version": "2.0.4",
+  "version": "2.0.5",
   "minAppVersion": "0.15.0",
   "description": "Record, transcribe, and transform voice notes into structured insights. Leverage Whisper or AssemblyAI and ChatGPT to fill in gaps, generate summaries, and visualize ideas — all seamlessly integrated within Obsidian.",
   "author": "Mike Alicea",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "obsidian-scribe-plugin",
-  "version": "2.0.4",
+  "version": "2.0.5",
   "description": "An Obsidian plugin for recording voice notes, transcribing the audio, and summarizing the text - All in one",
   "main": "build/main.js",
   "scripts": {

--- a/src/settings/settings.tsx
+++ b/src/settings/settings.tsx
@@ -14,10 +14,16 @@ import {
   type ScribeTemplate,
   NoteTemplateSettings,
 } from './components/NoteTemplateSettings';
+import { getDefaultPathSettings } from 'src/util/pathUtils';
 
 export enum TRANSCRIPT_PLATFORM {
   assemblyAi = 'assemblyAi',
   openAi = 'openAi',
+}
+
+export enum OBSIDIAN_PATHS {
+  noteFolder = 'matchObsidianNoteFolder',
+  resourceFolder = 'matchObsidianResourceFolder',
 }
 export interface ScribePluginSettings {
   assemblyAiApiKey: string;
@@ -42,8 +48,8 @@ export interface ScribePluginSettings {
 export const DEFAULT_SETTINGS: ScribePluginSettings = {
   assemblyAiApiKey: '',
   openAiApiKey: '',
-  recordingDirectory: '',
-  transcriptDirectory: '',
+  recordingDirectory: OBSIDIAN_PATHS.resourceFolder,
+  transcriptDirectory: OBSIDIAN_PATHS.noteFolder,
   transcriptPlatform: TRANSCRIPT_PLATFORM.openAi,
   isMultiSpeakerEnabled: false,
   llmModel: LLM_MODELS['gpt-4o'],
@@ -116,6 +122,10 @@ export class ScribeSettingsTab extends PluginSettingTab {
       .setDesc('Defaults to your resources folder')
       .addDropdown((component) => {
         component.addOption('', 'Vault folder');
+        component.addOption(
+          OBSIDIAN_PATHS.resourceFolder,
+          'Obsidian resource folder',
+        );
         for (const folder of foldersInVault) {
           const folderName = folder.path ? folder.path : 'Vault Folder';
           component.addOption(folder.path, folderName);
@@ -131,8 +141,11 @@ export class ScribeSettingsTab extends PluginSettingTab {
     new Setting(containerEl)
       .setName('Directory for transcripts')
       .setDesc('Defaults to your new note folder')
-      .addDropdown((component) => {
+      .addDropdown(async (component) => {
+        const defaultPathSettings = await getDefaultPathSettings(this.plugin);
+
         component.addOption('', 'Vault folder');
+        component.addOption(OBSIDIAN_PATHS.noteFolder, 'Obsidian note folder');
         for (const folder of foldersInVault) {
           const folderName = folder.path === '' ? 'Vault Folder' : folder.path;
           component.addOption(folder.path, folderName);

--- a/src/util/fileUtils.ts
+++ b/src/util/fileUtils.ts
@@ -1,16 +1,24 @@
 import { normalizePath, type TFile } from 'obsidian';
 
 import type ScribePlugin from 'src';
+import { OBSIDIAN_PATHS } from 'src/settings/settings';
+import { getDefaultPathSettings } from './pathUtils';
 
 export async function saveAudioRecording(
   plugin: ScribePlugin,
   recordingBuffer: ArrayBuffer,
   baseFileName: string,
 ) {
-  const pathToSave = plugin.settings.recordingDirectory;
+  const defaultPaths = await getDefaultPathSettings(plugin);
+  const pathToSave =
+    plugin.settings.recordingDirectory === OBSIDIAN_PATHS.resourceFolder
+      ? defaultPaths.defaultNewResourcePath
+      : plugin.settings.recordingDirectory;
   let fullPath = normalizePath(
     `${pathToSave}/${baseFileName}.${plugin.state.audioRecord?.fileExtension}`,
   );
+
+  console.log('Saving audio to path:', fullPath);
 
   const fileAlreadyExists = await plugin.app.vault.adapter.exists(
     fullPath,
@@ -37,9 +45,16 @@ export async function createNewNote(
   fileName: string,
 ): Promise<TFile> {
   try {
-    const pathToSave = plugin.settings.transcriptDirectory;
+    const defaultPaths = await getDefaultPathSettings(plugin);
+    const pathToSave =
+      plugin.settings.transcriptDirectory === OBSIDIAN_PATHS.noteFolder
+        ? defaultPaths.defaultNewFilePath
+        : plugin.settings.transcriptDirectory;
+
     const fullPath = `${pathToSave}/${fileName}.md`;
     let notePath = normalizePath(fullPath);
+
+    console.log('Saving note to path:', notePath);
 
     const fileAlreadyExists = await plugin.app.vault.adapter.exists(
       notePath,

--- a/src/util/pathUtils.ts
+++ b/src/util/pathUtils.ts
@@ -4,8 +4,14 @@ import type ScribePlugin from 'src';
 export async function getDefaultPathSettings(plugin: ScribePlugin) {
   const fileManager = plugin.app.fileManager;
 
+  const activeFile = plugin.app.workspace.getActiveFile();
+  /**
+   * This will use the active file path IFF the user has the setting in Obsidian
+   * Default Location for new notes set to "Same folder as active file".
+   * Otherwise, it will use the default new file path set in Obsidian.
+   */
   const defaultNewFilePath = normalizePath(
-    fileManager.getNewFileParent('', '').path,
+    fileManager.getNewFileParent(activeFile?.path || '', '').path,
   );
 
   const uniqueFileName = Date.now();


### PR DESCRIPTION
Improves path handling for users who want to use the same settings as are found in their obsidian settings for resources and notes.

Adds an option in the "Directory for recordings" and "Directory for transcripts" for "Obsidian resource folder" and "Obsidian note folder"