### PR TITLE
34 support paragraph splitting via assemblyai api

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "id": "scribe",
   "name": "Scribe",
-  "version": "2.0.8",
+  "version": "2.0.9",
   "minAppVersion": "0.15.0",
   "description": "Record, transcribe, and transform voice notes into structured insights. Leverage Whisper or AssemblyAI and ChatGPT to fill in gaps, generate summaries, and visualize ideas — all seamlessly integrated within Obsidian.",
   "author": "Mike Alicea",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "obsidian-scribe-plugin",
-  "version": "2.0.8",
+  "version": "2.0.9",
   "description": "An Obsidian plugin for recording voice notes, transcribing the audio, and summarizing the text - All in one",
   "main": "build/main.js",
   "scripts": {

--- a/src/util/assemblyAiUtil.ts
+++ b/src/util/assemblyAiUtil.ts
@@ -30,6 +30,7 @@ export async function transcribeAudioWithAssemblyAi(
     : baseParams;
 
   const transcript = await client.transcripts.transcribe(params);
+
   let formattedParagraphs: TranscriptParagraph[] | undefined;
   try {
     const { paragraphs } = await client.transcripts.paragraphs(transcript.id);


### PR DESCRIPTION
Implements #34 
# Adds in client.transcripts.paragraphs(transcript.id) when using AssemblyAI
Note creation will prioritize multi speaker if it is enabled, then move to paragraphs and finally to just a raw text block