### PR TITLE
Add pause-resume UI and link up to pre-existing functionality

### DIFF
--- a/src/modal/components/ModalRecordingButtons.tsx
+++ b/src/modal/components/ModalRecordingButtons.tsx
@@ -1,4 +1,9 @@
-import { TrashIcon, SaveIcon, MicVocal } from '../icons/icons';
+import { 
+  TrashIcon, 
+  SaveIcon, 
+  PauseIcon, 
+  ResumeIcon, 
+  MicVocal } from '../icons/icons';
 
 export function ModalRecordingButtons({
   active,
@@ -40,6 +45,24 @@ export function ModalRecordingButtons({
         >
           <TrashIcon />
           Reset
+        </button>
+
+        <button
+          className="scribe-btn"
+          onClick={handlePauseResume}
+          type="button"
+          disabled={isScribing}
+        >
+          {recordingState === "recording" && (
+            <>
+              <PauseIcon /> Pause
+            </>
+          )}
+          {recordingState === "paused" && (
+            <>
+              <ResumeIcon /> Resume
+            </>
+          )}
         </button>
 
         {/**

--- a/src/modal/icons/icons.tsx
+++ b/src/modal/icons/icons.tsx
@@ -58,6 +58,44 @@ export function TrashIcon() {
   );
 }
 
+export function PauseIcon() {
+  return (
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      width={24}
+      height={24}
+      fill="none"
+      stroke="currentColor"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      strokeWidth={2}
+      className="lucide lucide-pause"
+    >
+      <title>Pause Icon</title>
+      <path d="M10 4h-2v16h2V4zM16 4h-2v16h2V4z" />
+    </svg>
+  );
+}
+
+export function ResumeIcon() {
+  return (
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      width={24}
+      height={24}
+      fill="none"
+      stroke="currentColor"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      strokeWidth={2}
+      className="lucide lucide-play"
+    >
+      <title>Resume / Play Icon</title>
+      <path d="M6 4l14 8-14 8V4z" />
+    </svg>
+  );
+}
+
 export const CircleAlert = () => (
   <svg
     xmlns="http://www.w3.org/2000/svg"


### PR DESCRIPTION
<img width="681" height="543" alt="Screenshot from 2025-10-03 19-35-18" src="https://github.com/user-attachments/assets/95a54e09-6942-4489-b8f0-7af0439d457d" />
<img width="681" height="543" alt="Screenshot from 2025-10-03 19-35-09" src="https://github.com/user-attachments/assets/9bf1f732-7178-4339-bb56-afa6f015c415" />

The only thing it doesn't do yet is pause the timer. 

BTW:

The main branch was already failing though; this is when I ran the version of Scribe I had already installed before I started working on the pause-resume branch:

<img width="681" height="543" alt="image" src="https://github.com/user-attachments/assets/59ee8e3c-0e19-4a25-83fc-5798bbf1283b" />

So I couldn't test it all the way through. 