### PR TITLE
84 garbage decoding always fails

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
 	"id": "scribe",
 	"name": "Scribe",
-	"version": "2.2.0",
+	"version": "2.2.1",
 	"minAppVersion": "0.15.0",
 	"description": "Record, transcribe, and transform voice notes into structured insights. Leverage Whisper or AssemblyAI and ChatGPT to fill in gaps, generate summaries, and visualize ideas — all seamlessly integrated within Obsidian.",
 	"author": "Mike Alicea",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "obsidian-scribe-plugin",
-	"version": "2.2.0",
+	"version": "2.2.1",
 	"description": "An Obsidian plugin for recording voice notes, transcribing the audio, and summarizing the text - All in one",
 	"main": "build/main.js",
 	"scripts": {
@@ -25,8 +25,6 @@
 		"typescript": "^5.8.3"
 	},
 	"dependencies": {
-		"@ffmpeg/ffmpeg": "^0.12.15",
-		"@ffmpeg/util": "^0.12.2",
 		"@fix-webm-duration/fix": "^1.0.1",
 		"@langchain/core": "^0.3.40",
 		"@langchain/openai": "^0.5.10",

--- a/src/audioRecord/audioRecord.ts
+++ b/src/audioRecord/audioRecord.ts
@@ -6,8 +6,6 @@
 
 import { Notice } from 'obsidian';
 import { fixWebmDuration } from '@fix-webm-duration/fix';
-import { FFmpeg } from '@ffmpeg/ffmpeg';
-import { fetchFile, toBlobURL } from '@ffmpeg/util';
 
 import {
   mimeTypeToFileExtension,
@@ -25,17 +23,17 @@ export class AudioRecord {
   private mimeType: SupportedMimeType = pickMimeType('audio/webm; codecs=opus');
   private bitRate = 32000;
 
-  constructor(desiredFormat: 'webm' | 'mp3' = 'webm') {
+  constructor(desiredFormat: 'webm' = 'webm') {
     this.desiredFormat = desiredFormat;
     // We always record in WebM format because it's widely supported
-    // If MP3 is desired, we'll convert it later
+    // DEPRECATED: MP3
+    // If MP3 is desired, we'll wait for requests for it.  Our previous implementation caused issues on MacOS and iOS.
     this.fileExtension = desiredFormat;
   }
 
   async startRecording(deviceId?: string) {
-    const audioConstraints = deviceId && deviceId !== '' 
-      ? { deviceId: { exact: deviceId } }
-      : true;
+    const audioConstraints =
+      deviceId && deviceId !== '' ? { deviceId: { exact: deviceId } } : true;
 
     navigator.mediaDevices
       .getUserMedia({ audio: audioConstraints })
@@ -81,36 +79,6 @@ export class AudioRecord {
     this.mediaRecorder?.pause();
   }
 
-  async convertWebmToMp3(webmBlob: Blob): Promise<Blob> {
-    try {
-      const ffmpeg = new FFmpeg();
-      const baseURL = 'https://unpkg.com/@ffmpeg/core@0.12.6/dist/umd';
-      
-      // Load FFmpeg
-      await ffmpeg.load({
-        coreURL: await toBlobURL(`${baseURL}/ffmpeg-core.js`, 'text/javascript'),
-        wasmURL: await toBlobURL(`${baseURL}/ffmpeg-core.wasm`, 'application/wasm'),
-      });
-      
-      // Write input WebM file
-      await ffmpeg.writeFile('input.webm', await fetchFile(webmBlob));
-      
-      // Convert WebM to MP3
-      await ffmpeg.exec(['-i', 'input.webm', '-c:a', 'libmp3lame', '-q:a', '2', 'output.mp3']);
-      
-      // Read the output file
-      const data = await ffmpeg.readFile('output.mp3');
-      
-      // Create a Blob from the output data
-      const mp3Blob = new Blob([data], { type: 'audio/mp3' });
-      
-      return mp3Blob;
-    } catch (error) {
-      console.error('Error converting WebM to MP3:', error);
-      throw new Error(`Failed to convert WebM to MP3: ${error.message}`);
-    }
-  }
-
   stopRecording() {
     return new Promise<Blob>((resolve, reject) => {
       if (!this.mediaRecorder || this.mediaRecorder.state === 'inactive') {
@@ -139,19 +107,7 @@ export class AudioRecord {
           this.mediaRecorder = null;
           this.startTime = null;
 
-          // If MP3 is desired, convert the WebM blob to MP3
-          if (this.desiredFormat === 'mp3') {
-            try {
-              const mp3Blob = await this.convertWebmToMp3(fixedBlob);
-              resolve(mp3Blob);
-            } catch (conversionError) {
-              console.error('Error converting to MP3, falling back to WebM:', conversionError);
-              new Notice('Scribe: Failed to convert to MP3, saving as WebM instead');
-              resolve(fixedBlob);
-            }
-          } else {
-            resolve(fixedBlob);
-          }
+          resolve(fixedBlob);
         } catch (err) {
           console.log('Error during recording stop:', err);
           reject(err);

--- a/src/index.ts
+++ b/src/index.ts
@@ -229,13 +229,13 @@ export default class ScribePlugin extends Plugin {
 
       let fixedMermaidChart: string | undefined;
       if (brokenMermaidChart) {
-        const customBaseUrl = this.settings.useCustomOpenAiBaseUrl 
-          ? this.settings.customOpenAiBaseUrl 
+        const customBaseUrl = this.settings.useCustomOpenAiBaseUrl
+          ? this.settings.customOpenAiBaseUrl
           : undefined;
-        const customChatModel = this.settings.useCustomOpenAiBaseUrl 
-          ? this.settings.customChatModel 
+        const customChatModel = this.settings.useCustomOpenAiBaseUrl
+          ? this.settings.customChatModel
           : undefined;
-        
+
         fixedMermaidChart = (
           await llmFixMermaidChart(
             this.settings.openAiApiKey,
@@ -402,12 +402,10 @@ export default class ScribePlugin extends Plugin {
   ) {
     try {
       if (this.settings.isDisableLlmTranscription) {
-        new Notice(
-          `Scribe: 🎧 Transcription is disabled in settings`,
-        );
-        return "";
+        new Notice('Scribe: 🎧 Transcription is disabled in settings');
+        return '';
       }
-      
+
       new Notice(
         `Scribe: 🎧 Beginning transcription w/ ${this.settings.transcriptPlatform}`,
       );
@@ -422,11 +420,11 @@ export default class ScribePlugin extends Plugin {
               this.settings.openAiApiKey,
               audioBuffer,
               scribeOptions,
-              this.settings.useCustomOpenAiBaseUrl 
-                ? this.settings.customOpenAiBaseUrl 
+              this.settings.useCustomOpenAiBaseUrl
+                ? this.settings.customOpenAiBaseUrl
                 : undefined,
-              this.settings.useCustomOpenAiBaseUrl 
-                ? this.settings.customTranscriptModel 
+              this.settings.useCustomOpenAiBaseUrl
+                ? this.settings.customTranscriptModel
                 : undefined,
             );
 
@@ -453,11 +451,11 @@ export default class ScribePlugin extends Plugin {
   ) {
     new Notice('Scribe: 🧠 Sending to LLM to summarize');
 
-    const customBaseUrl = this.settings.useCustomOpenAiBaseUrl 
-      ? this.settings.customOpenAiBaseUrl 
+    const customBaseUrl = this.settings.useCustomOpenAiBaseUrl
+      ? this.settings.customOpenAiBaseUrl
       : undefined;
-    const customChatModel = this.settings.useCustomOpenAiBaseUrl 
-      ? this.settings.customChatModel 
+    const customChatModel = this.settings.useCustomOpenAiBaseUrl
+      ? this.settings.customChatModel
       : undefined;
 
     const llmSummary = await summarizeTranscript(

--- a/src/settings/GeneralSettingsTab.tsx
+++ b/src/settings/GeneralSettingsTab.tsx
@@ -96,15 +96,12 @@ function GeneralSettingsTab() {
       <SettingsSelect
         {...register('audioFileFormat')}
         name="Audio file format"
-        description="Choose the format for saving audio recordings. MP3 format will be converted from WebM on the client side."
+        description="Choose the format for saving audio recordings.  We currently only support WebM. MP3 is deprecated due to issues on MacOS and iOS."
+        // DEPRECATED: MP3 — If MP3 is desired, we'll wait for requests for it.  Our previous implementation caused issues on MacOS and iOS.
         valuesMapping={[
           {
             value: 'webm',
             displayName: 'WebM',
-          },
-          {
-            value: 'mp3',
-            displayName: 'MP3',
           },
         ]}
       />

--- a/src/settings/settings.tsx
+++ b/src/settings/settings.tsx
@@ -48,7 +48,7 @@ export interface ScribePluginSettings {
   noteTemplates: ScribeTemplate[];
   isFrontMatterLinkToScribe: boolean;
   selectedAudioDeviceId: string;
-  audioFileFormat: 'webm' | 'mp3';
+  audioFileFormat: 'webm';
   // Custom OpenAI settings
   useCustomOpenAiBaseUrl: boolean;
   customOpenAiBaseUrl: string;


### PR DESCRIPTION
Fixes #84 by simply removing MP3 option.  This undoes some of the work you did @tggo in #53 

I was not able to have MP3 work on any of my devices and having that option selected for some reason caused issues on mobile even though it was falling back to webm.  

My hunch is that https://github.com/Mikodin/obsidian-scribe/pull/53/files#diff-1d8319cec4160b01d4626c6447008f23752b7d950d5dc9dc825722105c152e82R145 was actually mutating `fixedBlob`, but I don't know for sure.