### PR TITLE
79 audio property is incorrect when using save audio append to current multiple recordings

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -173,8 +173,8 @@ Always includes a `fileTitle` field for note renaming.
 1. User clicks "Complete" → `plugin.scribe(scribeOptions)`
 2. `audioRecord.stopRecording()` → Blob → ArrayBuffer
 3. `saveAudioRecording()` → audio file in vault
-4. Create/get target note (new note or append to active file)
-5. Setup frontmatter (`audio: [[path]]`, `created_by: [[Scribe]]`)
+4. Create/get target note (new note or append to active file) via `resolveTargetNote`
+5. Update frontmatter immediately via `updateFrontMatter` (append `audio` list + `created_by`) so audio reference is preserved even if downstream stages fail
 6. Transcribe via OpenAI or AssemblyAI → transcript text
 7. Replace "# Audio in progress" placeholder with transcript
 8. (If not transcribe-only) Summarize via LLM → structured JSON

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
 	"id": "scribe",
 	"name": "Scribe",
-	"version": "2.2.8",
+	"version": "2.2.9",
 	"minAppVersion": "0.15.0",
 	"description": "Record, transcribe, and transform voice notes into structured insights. Leverage Whisper or AssemblyAI and ChatGPT to fill in gaps, generate summaries, and visualize ideas — all seamlessly integrated within Obsidian.",
 	"author": "Mike Alicea",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "obsidian-scribe-plugin",
-	"version": "2.2.8",
+	"version": "2.2.9",
 	"description": "An Obsidian plugin for recording voice notes, transcribing the audio, and summarizing the text - All in one",
 	"main": "build/main.js",
 	"scripts": {

--- a/src/index.ts
+++ b/src/index.ts
@@ -20,7 +20,7 @@ import {
   createNewNote,
   renameFile,
   saveAudioRecording,
-  setupFileFrontmatter,
+  updateFrontMatter,
 } from './util/fileUtils';
 import {
   mimeTypeToFileExtension,
@@ -322,12 +322,6 @@ export default class ScribePlugin extends Plugin {
       this.app.workspace.openLinkText(note?.path, currentPath, true);
     }
 
-    if (isSaveAudioFileActive) {
-      await setupFileFrontmatter(this, note, audioRecordingFile);
-    } else {
-      await setupFileFrontmatter(this, note);
-    }
-
     await this.cleanup();
 
     if (!isAppendToActiveFile) {
@@ -355,6 +349,12 @@ export default class ScribePlugin extends Plugin {
       transcriptTextToAppendToNote,
       inProgressHeaderToReplace,
     );
+
+    if (isSaveAudioFileActive) {
+      await updateFrontMatter(this, note, audioRecordingFile);
+    } else {
+      await updateFrontMatter(this, note);
+    }
 
     if (isOnlyTranscribeActive) {
       return;

--- a/src/index.ts
+++ b/src/index.ts
@@ -322,6 +322,12 @@ export default class ScribePlugin extends Plugin {
       this.app.workspace.openLinkText(note?.path, currentPath, true);
     }
 
+    if (isSaveAudioFileActive) {
+      await updateFrontMatter(this, note, audioRecordingFile);
+    } else {
+      await updateFrontMatter(this, note);
+    }
+
     await this.cleanup();
 
     if (!isAppendToActiveFile) {
@@ -349,12 +355,6 @@ export default class ScribePlugin extends Plugin {
       transcriptTextToAppendToNote,
       inProgressHeaderToReplace,
     );
-
-    if (isSaveAudioFileActive) {
-      await updateFrontMatter(this, note, audioRecordingFile);
-    } else {
-      await updateFrontMatter(this, note);
-    }
 
     if (isOnlyTranscribeActive) {
       return;

--- a/src/index.ts
+++ b/src/index.ts
@@ -169,7 +169,19 @@ export default class ScribePlugin extends Plugin {
       const { recordingBuffer, recordingFile } =
         await this.handleStopAndSaveRecording(baseFileName);
 
+      const note = await this.resolveTargetNote(
+        baseFileName,
+        scribeOptions.isAppendToActiveFile,
+      );
+
+      if (scribeOptions.isSaveAudioFileActive) {
+        await updateFrontMatter(this, note, recordingFile);
+      } else {
+        await updateFrontMatter(this, note);
+      }
+
       await this.handleScribeFile({
+        note,
         audioRecordingFile: recordingFile,
         audioRecordingBuffer: recordingBuffer,
         scribeOptions: scribeOptions,
@@ -212,10 +224,26 @@ export default class ScribePlugin extends Plugin {
         new Notice('Scribe: ⚠️ This file type is not supported.');
         return;
       }
+      const baseFileName = formatFilenamePrefix(
+        this.settings.recordingFilenamePrefix,
+        this.settings.dateFilenameFormat,
+      );
 
       const audioFileBuffer = await this.app.vault.readBinary(audioFile);
 
+      const note = await this.resolveTargetNote(
+        baseFileName,
+        scribeOptions.isAppendToActiveFile,
+      );
+
+      if (scribeOptions.isSaveAudioFileActive) {
+        await updateFrontMatter(this, note, audioFile);
+      } else {
+        await updateFrontMatter(this, note);
+      }
+
       await this.handleScribeFile({
+        note,
         audioRecordingFile: audioFile,
         audioRecordingBuffer: audioFileBuffer,
         scribeOptions: scribeOptions,
@@ -290,11 +318,32 @@ export default class ScribePlugin extends Plugin {
     return { recordingBuffer, recordingFile };
   }
 
+  private async resolveTargetNote(
+    baseFileName: string,
+    isAppendToActiveFile: boolean,
+  ): Promise<TFile> {
+    let note = isAppendToActiveFile
+      ? (this.app.workspace.getActiveFile() as TFile)
+      : await createNewNote(this, baseFileName);
+
+    if (!note) {
+      new Notice('Scribe: ⚠️ No active file to append to, creating new one!');
+      note = (await createNewNote(this, baseFileName)) as TFile;
+
+      const currentPath = this.app.workspace.getActiveFile()?.path ?? '';
+      this.app.workspace.openLinkText(note.path, currentPath, true);
+    }
+
+    return note;
+  }
+
   async handleScribeFile({
+    note,
     audioRecordingFile,
     audioRecordingBuffer,
     scribeOptions,
   }: {
+    note: TFile;
     audioRecordingFile: TFile;
     audioRecordingBuffer: ArrayBuffer;
     scribeOptions: ScribeOptions;
@@ -305,28 +354,6 @@ export default class ScribePlugin extends Plugin {
       isSaveAudioFileActive,
       activeNoteTemplate,
     } = scribeOptions;
-    const scribeNoteFilename = `${formatFilenamePrefix(
-      this.settings.noteFilenamePrefix,
-      this.settings.dateFilenameFormat,
-    )}`;
-
-    let note = isAppendToActiveFile
-      ? (this.app.workspace.getActiveFile() as TFile)
-      : await createNewNote(this, scribeNoteFilename);
-
-    if (!note) {
-      new Notice('Scribe: ⚠️ No active file to append to, creating new one!');
-      note = (await createNewNote(this, scribeNoteFilename)) as TFile;
-
-      const currentPath = this.app.workspace.getActiveFile()?.path ?? '';
-      this.app.workspace.openLinkText(note?.path, currentPath, true);
-    }
-
-    if (isSaveAudioFileActive) {
-      await updateFrontMatter(this, note, audioRecordingFile);
-    } else {
-      await updateFrontMatter(this, note);
-    }
 
     await this.cleanup();
 


### PR DESCRIPTION
Fixes bug that replaced the audio file name in the frontmatter when appending.
Also improves our flow for adding to the meta data, it's done immediately after the file is recorded, this improves the scenario when a transcription failure happens and we want to retranscribe it and have to go digging for the file.  It's now easily linked in the frontmatter immediately