### PR TITLE
77 Feat: additional text to send with the transcript to llm personal assistant mode

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
 	"id": "scribe",
 	"name": "Scribe",
-	"version": "2.3.2",
+	"version": "2.3.3",
 	"minAppVersion": "0.15.0",
 	"description": "Record, transcribe, and transform voice notes into structured insights. Leverage Whisper or AssemblyAI and ChatGPT to fill in gaps, generate summaries, and visualize ideas — all seamlessly integrated within Obsidian.",
 	"author": "Mike Alicea",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "obsidian-scribe-plugin",
-	"version": "2.3.2",
+	"version": "2.3.3",
 	"description": "An Obsidian plugin for recording voice notes, transcribing the audio, and summarizing the text - All in one",
 	"main": "build/main.js",
 	"scripts": {

--- a/src/index.ts
+++ b/src/index.ts
@@ -62,6 +62,7 @@ export interface ScribeOptions {
   transcriptPlatform: TRANSCRIPT_PLATFORM;
   llmModel: LLM_MODELS;
   activeNoteTemplate: ScribeTemplate;
+  additionalSystemPrompt?: string;
 }
 
 export default class ScribePlugin extends Plugin {

--- a/src/modal/components/options/ModalRecordingOptions.tsx
+++ b/src/modal/components/options/ModalRecordingOptions.tsx
@@ -11,6 +11,7 @@ import {
 } from 'src/util/consts';
 import { ButtonComponent } from 'obsidian';
 import type { ScribeTemplate } from 'src/settings/components/NoteTemplateSettings';
+import { ModalSystemPromptOption } from './ModalSystemPromptOption';
 
 export function ModalRecordingOptions({
   options,
@@ -91,6 +92,8 @@ export function ModalRecordingOptions({
           Multi-speaker enabled
         </label>
       )}
+
+      <ModalSystemPromptOption options={options} setOptions={setOptions} />
 
       <SettingsItem
         name="Active template"

--- a/src/modal/components/options/ModalSystemPromptOption.tsx
+++ b/src/modal/components/options/ModalSystemPromptOption.tsx
@@ -1,0 +1,65 @@
+import { useState } from 'react';
+import type { ScribeOptions } from 'src';
+
+export function ModalSystemPromptOption({
+  options,
+  setOptions,
+}: {
+  options: ScribeOptions;
+  setOptions: React.Dispatch<ScribeOptions>;
+}) {
+  const [isPromptExpanded, setIsPromptExpanded] = useState(false);
+
+  const handleOptionsChange = (updatedOptions: Partial<ScribeOptions>) => {
+    setOptions({
+      ...options,
+      ...updatedOptions,
+    });
+  };
+
+  const hasSystemPrompt = Boolean(options.additionalSystemPrompt?.trim());
+
+  return (
+    <div className="scribe-system-prompt-option">
+      <button
+        onClick={() => setIsPromptExpanded(!isPromptExpanded)}
+        type="button"
+        className="scribe-settings-btn"
+      >
+        Add to system prompt{hasSystemPrompt && ' ✅'}
+      </button>
+      {isPromptExpanded && (
+        <>
+          <textarea
+            placeholder="Additional context or instructions for the summary"
+            value={options.additionalSystemPrompt ?? ''}
+            onChange={(e) => {
+              handleOptionsChange({ additionalSystemPrompt: e.target.value });
+            }}
+            rows={3}
+            style={{
+              width: '100%',
+              overflow: 'visible',
+              height: 'auto',
+            }}
+            onFocus={(e) => {
+              const target = e.target as HTMLTextAreaElement;
+              target.style.height = `${target.scrollHeight}px`;
+            }}
+            onInput={(e) => {
+              const target = e.target as HTMLTextAreaElement;
+              target.style.height = `${target.scrollHeight}px`;
+            }}
+          />
+          <button
+            onClick={() => setIsPromptExpanded(false)}
+            type="button"
+            className="scribe-settings-btn"
+          >
+            Ok
+          </button>
+        </>
+      )}
+    </div>
+  );
+}

--- a/src/modal/scribeControlsModal.tsx
+++ b/src/modal/scribeControlsModal.tsx
@@ -67,6 +67,7 @@ const ScribeModal: React.FC<{ plugin: ScribePlugin }> = ({ plugin }) => {
     transcriptPlatform: plugin.settings.transcriptPlatform,
     llmModel: plugin.settings.llmModel,
     activeNoteTemplate: plugin.settings.activeNoteTemplate,
+    additionalSystemPrompt: '',
   });
 
   useEffect(() => {

--- a/src/styles.css
+++ b/src/styles.css
@@ -160,6 +160,19 @@ If your plugin does not need CSS, delete this file.
   }
 }
 
+.scribe-system-prompt-option {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  align-self: stretch;
+  gap: 0.5em;
+  margin: 0.5em 0;
+
+  textarea {
+    width: 100%;
+  }
+}
+
 button[role="tab"].settings-tab {
   border: 0;
   background-color: transparent;

--- a/src/util/openAiUtils.ts
+++ b/src/util/openAiUtils.ts
@@ -100,7 +100,11 @@ async function transcribeAudio(
 export async function summarizeTranscript(
   openAiKey: string,
   transcript: string,
-  { scribeOutputLanguage, activeNoteTemplate }: ScribeOptions,
+  {
+    scribeOutputLanguage,
+    activeNoteTemplate,
+    additionalSystemPrompt,
+  }: ScribeOptions,
   llmModel: LLM_MODELS = LLM_MODELS['gpt-4o'],
   customBaseUrl?: string,
   customChatModel?: string,
@@ -143,6 +147,14 @@ export async function summarizeTranscript(
   if (scribeOutputLanguage) {
     messages.push(
       new SystemMessage(`Please respond in ${scribeOutputLanguage} language`),
+    );
+  }
+
+  if (additionalSystemPrompt?.trim()) {
+    messages.push(
+      new SystemMessage(
+        `The user has provided additional context and instructions for this summary:\n<user-context>\n${additionalSystemPrompt}\n</user-context>`,
+      ),
     );
   }
 


### PR DESCRIPTION
## Add per-session "Add to system prompt" option for transcript summaries

Closes #77

### Screenshot
<img width="656" height="857" alt="image" src="https://github.com/user-attachments/assets/27afa0e0-9e85-44fd-82ae-0e5e853720eb" />


### What

Adds a new option in the recording modal that lets you provide additional, one-off context or instructions to the LLM before it summarizes your transcript — e.g. names of people in the meeting, what the recording is about, or how you want the summary framed ("personal assistant mode").

### How it works

- **New modal option** (`ModalSystemPromptOption`): a collapsible "Add to system prompt" button in the recording options panel. Clicking it expands an auto-resizing textarea; a ✅ indicator shows when a prompt is set. Rendered via a new `scribe-system-prompt-option` style block.
- **New `ScribeOptions` field**: `additionalSystemPrompt?: string`, initialized empty per modal session — it is intentionally **not persisted** to settings, since this context is usually specific to a single recording.
- **LLM integration** (`summarizeTranscript` in `openAiUtils.ts`): when the prompt is non-empty, an extra `SystemMessage` is appended to the message chain, wrapping the user's text in a `<user-context>` block with a preamble explaining it is user-provided context for the summary.

### Notes

- Only affects the summarization step; transcription is unchanged.
- Whitespace-only input is ignored (`?.trim()` guard).
- Also bumps the plugin version to 2.3.3 (`manifest.json`, `package.json`).

### Testing

- Verified the option expands/collapses in the modal, the ✅ indicator reflects state, and the textarea auto-grows with content.
- Confirmed the extra system message is only sent when a non-empty prompt is provided and that summaries respect the added instructions.