### PR TITLE
Feat update model options for OpenAI model selection

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
 	"id": "scribe",
 	"name": "Scribe",
-	"version": "2.3.3",
+	"version": "2.3.4",
 	"minAppVersion": "0.15.0",
 	"description": "Record, transcribe, and transform voice notes into structured insights. Leverage Whisper or AssemblyAI and ChatGPT to fill in gaps, generate summaries, and visualize ideas — all seamlessly integrated within Obsidian.",
 	"author": "Mike Alicea",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "obsidian-scribe-plugin",
-	"version": "2.3.3",
+	"version": "2.3.4",
 	"description": "An Obsidian plugin for recording voice notes, transcribing the audio, and summarizing the text - All in one",
 	"main": "build/main.js",
 	"scripts": {

--- a/src/settings/components/AiModelSettings.tsx
+++ b/src/settings/components/AiModelSettings.tsx
@@ -204,11 +204,11 @@ export const AiModelSettings: React.FC<{
 
           <SettingsItem
             name="Custom chat model"
-            description="The model name to use for chat/summarization (e.g., gpt-4, llama-3.1-8b-instruct, etc.)"
+            description="The model name to use for chat/summarization (e.g., gpt-5.6-terra, llama-3.1-8b-instruct, etc.)"
             control={
               <input
                 type="text"
-                placeholder="gpt-4o"
+                placeholder="gpt-5.6-terra"
                 value={customChatModel}
                 onChange={(e) => handleCustomChatModelChange(e.target.value)}
                 className="text-input"

--- a/src/settings/settings.tsx
+++ b/src/settings/settings.tsx
@@ -63,7 +63,7 @@ export const DEFAULT_SETTINGS: ScribePluginSettings = {
   transcriptDirectory: OBSIDIAN_PATHS.noteFolder,
   transcriptPlatform: TRANSCRIPT_PLATFORM.openAi,
   isMultiSpeakerEnabled: false,
-  llmModel: LLM_MODELS['gpt-4o'],
+  llmModel: LLM_MODELS['gpt-5.6-terra'],
   noteFilenamePrefix: 'scribe-{{date}}-',
   recordingFilenamePrefix: 'scribe-recording-{{date}}',
   dateFilenameFormat: 'YYYY-MM-DD',

--- a/src/util/openAiUtils.ts
+++ b/src/util/openAiUtils.ts
@@ -16,11 +16,27 @@ import { LanguageOptions } from './consts';
 import { convertToSafeJsonKey } from './textUtil';
 
 export enum LLM_MODELS {
+  'gpt-5.6-sol' = 'gpt-5.6-sol',
+  'gpt-5.6-terra' = 'gpt-5.6-terra',
+  'gpt-5.6-luna' = 'gpt-5.6-luna',
+  'gpt-5.5' = 'gpt-5.5',
+  'gpt-5.1' = 'gpt-5.1',
+  'gpt-5' = 'gpt-5',
+  'gpt-5-mini' = 'gpt-5-mini',
+  'gpt-5-nano' = 'gpt-5-nano',
   'gpt-4.1' = 'gpt-4.1',
   'gpt-4.1-mini' = 'gpt-4.1-mini',
   'gpt-4o' = 'gpt-4o',
   'gpt-4o-mini' = 'gpt-4o-mini',
   'gpt-4-turbo' = 'gpt-4-turbo',
+}
+
+/**
+ * GPT-5 family and o-series reasoning models only accept the default
+ * temperature (1) on the Chat Completions API and 400 on anything else.
+ */
+function supportsCustomTemperature(model: string) {
+  return !/^(gpt-5|o\d)/.test(model);
 }
 
 const MAX_CHUNK_SIZE = 25 * 1024 * 1024;
@@ -105,7 +121,7 @@ export async function summarizeTranscript(
     activeNoteTemplate,
     additionalSystemPrompt,
   }: ScribeOptions,
-  llmModel: LLM_MODELS = LLM_MODELS['gpt-4o'],
+  llmModel: LLM_MODELS = LLM_MODELS['gpt-5.6-terra'],
   customBaseUrl?: string,
   customChatModel?: string,
 ) {
@@ -139,7 +155,7 @@ export async function summarizeTranscript(
   const model = new ChatOpenAI({
     model: modelToUse,
     apiKey: openAiKey,
-    temperature: 0.5,
+    ...(supportsCustomTemperature(modelToUse) && { temperature: 0.5 }),
     ...(customBaseUrl && { configuration: { baseURL: customBaseUrl } }),
   });
   const messages = [new SystemMessage(systemPrompt)];
@@ -186,7 +202,7 @@ export async function summarizeTranscript(
 export async function llmFixMermaidChart(
   openAiKey: string,
   brokenMermaidChart: string,
-  llmModel: LLM_MODELS = LLM_MODELS['gpt-4o'],
+  llmModel: LLM_MODELS = LLM_MODELS['gpt-5.6-terra'],
   customBaseUrl?: string,
   customChatModel?: string,
 ) {
@@ -207,7 +223,7 @@ Thank you
   const model = new ChatOpenAI({
     model: modelToUse,
     apiKey: openAiKey,
-    temperature: 0.3,
+    ...(supportsCustomTemperature(modelToUse) && { temperature: 0.3 }),
     ...(customBaseUrl && { configuration: { baseURL: customBaseUrl } }),
   });
   const messages = [new SystemMessage(systemPrompt)];


### PR DESCRIPTION
## Update AI model options to latest OpenAI models

### What

- **New models in the summary LLM selector** — adds the GPT-5.6 family (`gpt-5.6-sol`, `gpt-5.6-terra`, `gpt-5.6-luna`) plus `gpt-5.5`, `gpt-5.1`, `gpt-5`, `gpt-5-mini`, and `gpt-5-nano` to the `LLM_MODELS` enum, which drives both the settings dropdown and the modal's model picker. Existing gpt-4.x entries are kept so previously saved selections still resolve.
- **New default model** — fresh installs now default to `gpt-5.6-terra` (OpenAI's recommended balanced tier). Existing users keep their saved setting.
- **Temperature guard** — GPT-5-family and o-series models reject any non-default `temperature` on the Chat Completions API (400 error). Summarization and mermaid-fix calls now only pass their hardcoded temperatures (`0.5` / `0.3`) to models that support it.
- **Docs touch-up** — custom chat model placeholder/example text updated from `gpt-4o` to `gpt-5.6-terra`.

### Why

The selector topped out at `gpt-4.1`, several generations behind current OpenAI offerings. Without the temperature guard, simply adding the new models would have broken summarization with a 400 on every GPT-5-family request.

### Testing

- `npm run format:write` and `npm run build:prod` (typecheck + build) pass cleanly.
- No settings migration needed: saved `llmModel` values remain valid enum members.