### PR TITLE
Scribe 2.3.7 feat: add AssemblyAI LLM support with model selection and configuration

### DIFF
--- a/src/aiProviders/llm/llmAdapter.ts
+++ b/src/aiProviders/llm/llmAdapter.ts
@@ -3,6 +3,7 @@ import { PROCESS_PLATFORM } from 'src/util/consts';
 import type { LlmSummary, SummaryOptions } from '../prompts';
 import { createAnthropicLlmAdapter } from './anthropicLlm';
 import {
+  ASSEMBLYAI_LLM_BASE_URL,
   createOpenAiCompatibleLlmAdapter,
   GEMINI_OPENAI_BASE_URL,
   OPENROUTER_BASE_URL,
@@ -55,6 +56,13 @@ export function resolveLlmConfig(
         apiKey: settings.openRouterApiKey,
         model: overrides?.model ?? settings.openRouterModel,
         baseUrl: OPENROUTER_BASE_URL,
+      };
+    case PROCESS_PLATFORM.assemblyAi:
+      return {
+        platform,
+        apiKey: settings.assemblyAiApiKey,
+        model: overrides?.model ?? settings.assemblyAiLlmModel,
+        baseUrl: ASSEMBLYAI_LLM_BASE_URL,
       };
     case PROCESS_PLATFORM.customOpenAi:
       return {

--- a/src/aiProviders/llm/openAiCompatibleLlm.ts
+++ b/src/aiProviders/llm/openAiCompatibleLlm.ts
@@ -42,6 +42,29 @@ export const DEFAULT_GEMINI_MODEL = GEMINI_MODELS['gemini-3.5-flash'];
 
 export const OPENROUTER_BASE_URL = 'https://openrouter.ai/api/v1';
 
+// AssemblyAI's OpenAI-compatible LLM Gateway proxies ~25 models (Claude,
+// Gemini, GPT, Qwen, Kimi). Lets a user keep transcription + summarization
+// within AssemblyAI's data-handling envelope.
+export const ASSEMBLYAI_LLM_BASE_URL = 'https://llm-gateway.assemblyai.com/v1';
+export const DEFAULT_ASSEMBLYAI_LLM_MODEL = 'claude-sonnet-4-6';
+// The gateway defaults max_tokens to 1000 when omitted (unlike OpenAI/Gemini,
+// which use the model's own high default). A full structured note easily
+// exceeds that and gets truncated mid-JSON, so send an explicit generous cap.
+export const ASSEMBLYAI_LLM_MAX_TOKENS = 8192;
+// Seed list for the model combobox; free text is still allowed. The gateway
+// catalog drifts, so this is a convenience list, not an exhaustive one.
+export const ASSEMBLYAI_LLM_MODEL_IDS = [
+  'claude-sonnet-4-6',
+  'claude-opus-4-6',
+  'claude-haiku-4-5-20251001',
+  'gemini-3.5-flash',
+  'gemini-2.5-flash',
+  'gemini-2.5-pro',
+  'gpt-5.1',
+  'gpt-5-mini',
+  'gpt-4.1',
+] as const;
+
 // Gemini's OpenAI-compatible endpoint — keeps Google off LangChain's
 // @langchain/google-genai package, which bundles node:async_hooks and
 // crashes Obsidian mobile (the PR #101 revert).
@@ -58,15 +81,21 @@ function supportsCustomTemperature(model: string) {
 
 function createChatModel(config: LlmAdapterConfig, temperature: number) {
   // The model-name heuristic only holds for OpenAI's own catalog; OpenRouter
-  // routes to arbitrary providers, so let those models use their defaults.
+  // and the AssemblyAI gateway route to arbitrary providers, so let those
+  // models use their defaults.
+  const isMultiProviderGateway =
+    config.platform === PROCESS_PLATFORM.openRouter ||
+    config.platform === PROCESS_PLATFORM.assemblyAi;
   const useTemperature =
-    config.platform !== PROCESS_PLATFORM.openRouter &&
-    supportsCustomTemperature(config.model);
+    !isMultiProviderGateway && supportsCustomTemperature(config.model);
+
+  const isAssemblyAiGateway = config.platform === PROCESS_PLATFORM.assemblyAi;
 
   return new ChatOpenAI({
     model: config.model,
     apiKey: config.apiKey,
     ...(useTemperature && { temperature }),
+    ...(isAssemblyAiGateway && { maxTokens: ASSEMBLYAI_LLM_MAX_TOKENS }),
     configuration: {
       fetch: obsidianFetch,
       ...(config.baseUrl && { baseURL: config.baseUrl }),
@@ -84,11 +113,18 @@ export function createOpenAiCompatibleLlmAdapter(
     ): Promise<LlmSummary> {
       const model = createChatModel(config, 0.5);
 
+      // Combine the main prompt and the extra instructions into a SINGLE system
+      // message. Gateways that route to Anthropic models (the AssemblyAI LLM
+      // Gateway with a Claude model) collapse the OpenAI `system` messages into
+      // Anthropic's single `system` field; sending multiple risks the
+      // transcript-bearing first message being dropped.
+      const systemPrompt = [
+        buildSummarySystemPrompt(transcript),
+        ...buildSummaryExtraInstructions(options),
+      ].join('\n\n');
+
       const messages = [
-        new SystemMessage(buildSummarySystemPrompt(transcript)),
-        ...buildSummaryExtraInstructions(options).map(
-          (instruction) => new SystemMessage(instruction),
-        ),
+        new SystemMessage(systemPrompt),
         // Gemini's OpenAI-compat endpoint maps system messages to
         // system_instruction and 400s ("contents is not specified") if no
         // user message remains — same requirement as the Anthropic adapter.

--- a/src/aiProviders/providerMetadata.ts
+++ b/src/aiProviders/providerMetadata.ts
@@ -157,6 +157,18 @@ export const LLM_PROVIDERS: Record<PROCESS_PLATFORM, ProviderMetadata> = {
       policyUrl: 'https://openrouter.ai/docs/features/privacy-and-logging',
     },
   },
+  [PROCESS_PLATFORM.assemblyAi]: {
+    displayName: 'AssemblyAI (LLM Gateway)',
+    apiKeySettingsField: 'assemblyAiApiKey',
+    keyConsoleUrl: 'https://www.assemblyai.com/app/account',
+    privacy: {
+      retentionSummary:
+        'Routed through AssemblyAI to the selected model provider; retention/training depend on that provider and your AssemblyAI settings',
+      trainsOnApiData: 'opt-out',
+      policyUrl:
+        'https://www.assemblyai.com/docs/faq/what-is-your-data-retention-policy',
+    },
+  },
   [PROCESS_PLATFORM.customOpenAi]: {
     displayName: 'Custom (OpenAI-compatible)',
     apiKeySettingsField: 'openAiApiKey',

--- a/src/aiProviders/transcription/assemblyAiTranscriber.ts
+++ b/src/aiProviders/transcription/assemblyAiTranscriber.ts
@@ -24,7 +24,7 @@ export async function transcribeAudioWithAssemblyAi(
     format_text: true,
     speaker_labels: isMultiSpeakerEnabled,
     /** Choosing universal-3-pro as default, cost is similar.  Will fallback to Universal-2 if language is not supported */
-    speech_models: ['universal-3-pro', 'universal-2'],
+    speech_models: ['universal-3-5-pro', 'universal-2'],
   };
 
   const params = useAudioFileLanguageSetting

--- a/src/modal/components/options/ModalAiModelOptions.tsx
+++ b/src/modal/components/options/ModalAiModelOptions.tsx
@@ -1,6 +1,7 @@
 import type ScribePlugin from 'src';
 import type { ScribeOptions } from 'src';
 import { resolveLlmConfig } from 'src/aiProviders/llm/llmAdapter';
+import { ASSEMBLYAI_LLM_MODEL_IDS } from 'src/aiProviders/llm/openAiCompatibleLlm';
 import {
   LLM_PROVIDERS,
   TRANSCRIPT_PROVIDERS,
@@ -136,6 +137,26 @@ function ModalLlmModelPicker({
         />
         <datalist id="scribe-modal-openrouter-models">
           {openRouterModelIds.map((modelId) => (
+            <option key={modelId} value={modelId} />
+          ))}
+        </datalist>
+      </>
+    );
+  }
+
+  // AssemblyAI gateway: seeded combobox, any model id from the gateway allowed
+  if (processPlatform === PROCESS_PLATFORM.assemblyAi) {
+    return (
+      <>
+        <input
+          type="text"
+          list="scribe-modal-assemblyai-models"
+          value={llmModel}
+          placeholder="claude-sonnet-4-6"
+          onChange={(e) => onModelChange(e.target.value)}
+        />
+        <datalist id="scribe-modal-assemblyai-models">
+          {ASSEMBLYAI_LLM_MODEL_IDS.map((modelId) => (
             <option key={modelId} value={modelId} />
           ))}
         </datalist>

--- a/src/settings/components/ProviderSettingsSections.tsx
+++ b/src/settings/components/ProviderSettingsSections.tsx
@@ -1,5 +1,6 @@
 import { ANTHROPIC_MODELS } from 'src/aiProviders/llm/anthropicLlm';
 import {
+  ASSEMBLYAI_LLM_MODEL_IDS,
   GEMINI_MODELS,
   LLM_MODELS,
 } from 'src/aiProviders/llm/openAiCompatibleLlm';
@@ -93,6 +94,13 @@ export function LlmProviderSection({
         <>
           <OpenRouterApiKeyInput />
           <OpenRouterModelInput />
+        </>
+      );
+    case PROCESS_PLATFORM.assemblyAi:
+      return (
+        <>
+          <AssemblyAiApiKeyInput />
+          <AssemblyAiLlmModelInput />
         </>
       );
     case PROCESS_PLATFORM.customOpenAi:
@@ -275,6 +283,19 @@ function OpenRouterModelInput() {
       description="Type to search the OpenRouter catalog, or enter any model id from https://openrouter.ai/models"
       placeholder="anthropic/claude-sonnet-5"
       options={modelIds}
+    />
+  );
+}
+
+function AssemblyAiLlmModelInput() {
+  const { register } = useSettingsForm();
+  return (
+    <SettingsCombobox
+      {...register('assemblyAiLlmModel')}
+      name="AssemblyAI model"
+      description="Type to search common gateway models, or enter any model id from https://www.assemblyai.com/docs/llm-gateway/available-models"
+      placeholder="claude-sonnet-4-6"
+      options={[...ASSEMBLYAI_LLM_MODEL_IDS]}
     />
   );
 }

--- a/src/settings/settings.tsx
+++ b/src/settings/settings.tsx
@@ -9,6 +9,7 @@ import {
   DEFAULT_ANTHROPIC_MODEL,
 } from 'src/aiProviders/llm/anthropicLlm';
 import {
+  DEFAULT_ASSEMBLYAI_LLM_MODEL,
   DEFAULT_GEMINI_MODEL,
   type GEMINI_MODELS,
   LLM_MODELS,
@@ -52,6 +53,7 @@ export interface ScribePluginSettings {
   anthropicModel: ANTHROPIC_MODELS;
   geminiModel: GEMINI_MODELS;
   openRouterModel: string;
+  assemblyAiLlmModel: string;
   recordingFilenamePrefix: string;
   noteFilenamePrefix: string;
   dateFilenameFormat: string;
@@ -90,6 +92,7 @@ export const DEFAULT_SETTINGS: ScribePluginSettings = {
   anthropicModel: DEFAULT_ANTHROPIC_MODEL,
   geminiModel: DEFAULT_GEMINI_MODEL,
   openRouterModel: 'anthropic/claude-sonnet-5',
+  assemblyAiLlmModel: DEFAULT_ASSEMBLYAI_LLM_MODEL,
   noteFilenamePrefix: 'scribe-{{date}}-',
   recordingFilenamePrefix: 'scribe-recording-{{date}}',
   dateFilenameFormat: 'YYYY-MM-DD',

--- a/src/util/consts.ts
+++ b/src/util/consts.ts
@@ -19,6 +19,7 @@ export enum PROCESS_PLATFORM {
   anthropic = 'anthropic',
   google = 'google',
   openRouter = 'openRouter',
+  assemblyAi = 'assemblyAi',
   customOpenAi = 'customOpenAi',
 }
 


### PR DESCRIPTION
# Add AssemblyAI as an LLM summarization provider

## Summary

Adds AssemblyAI's LLM Gateway as a summarization provider, so a user can run both transcription and LLM summarization through AssemblyAI — keeping data within a single vendor's privacy envelope (the motivation behind this ZDR / no-training branch) instead of sending transcripts to a second provider.

Because the gateway is OpenAI-compatible, it routes through the existing createOpenAiCompatibleLlmAdapter (LangChain ChatOpenAI + obsidianFetch + a baseURL override) — the same mechanism already used for Gemini and OpenRouter. No new transcription/LLM call logic was required; this is almost entirely wiring a new provider through the existing data-driven plumbing.

## What changed

New provider wiring
- src/util/consts.ts — added assemblyAi to the PROCESS_PLATFORM enum.
- src/aiProviders/llm/openAiCompatibleLlm.ts — added the gateway base URL, default model (claude-sonnet-4-6), and a seed list of common model IDs.
- src/aiProviders/llm/llmAdapter.ts — resolveLlmConfig case mapping the provider to assemblyAiApiKey + assemblyAiLlmModel + the gateway base URL. createLlmAdapter needed no change (non-Anthropic already routes to the OpenAI-compat adapter).
- src/aiProviders/providerMetadata.ts — LLM_PROVIDERS entry (drives the settings dropdown, privacy card, and missing-key checks).
- src/settings/settings.tsx — new assemblyAiLlmModel setting, defaulted to claude-sonnet-4-6.

UI (free-text model combobox, mirroring OpenRouter)
- src/settings/components/ProviderSettingsSections.tsx — AssemblyAI section reusing the existing API-key input + a combobox seeded with known model IDs (any gateway model ID allowed).
- src/modal/components/options/ModalAiModelOptions.tsx — matching combobox branch in the per-run modal picker.

### Bug fixes (gateway-specific)

Summarization initially failed only with AssemblyAI. Two gateway behaviors differ from OpenAI/Gemini/OpenRouter, both fixed in openAiCompatibleLlm.ts:

1. Output truncation — the gateway defaults max_tokens to 1000 when omitted (unlike OpenAI/Gemini, which use the model's high default). LangChain doesn't send max_tokens, so full structured notes were truncated mid-JSON and failed to parse. Fixed by sending an explicit maxTokens: 8192 for the gateway.
2. Dropped transcript — the transcript lives in the first system message, and we always send ≥2 system messages (the language instruction defaults to en). When the gateway collapses OpenAI's multiple system messages into Anthropic's single system field for Claude models, the transcript-bearing message could be lost. Fixed by merging the main prompt + extra instructions into a single system message (behavior-equivalent for the other OpenAI-compat providers).

## ZDR note

No special request headers are needed — Zero Data Retention on the LLM Gateway is an account-level arrangement (executed BAA + training opt-out + optional TTL) and applies
only when routing to Anthropic or Google models, not GPT/Qwen/Kimi. The de ZDR-eligible; users who select a gpt-* model in the combobox fall outsidethe ZDR envelope.

## Testing

- npm run format:write, npm run lint:write, npm run build:prod all pass cleanly (incl. the mobile-safety check).
- Manual verification still needed in Obsidian: with an AssemblyAI key ander selected, confirm the note gets its summary sections + LLM-suggestedtitle. If it fails, the gateway's error body surfaces in the console via [obsidianFetch] error body:.

(Note: the branch also switches the AssemblyAI transcription default speech model to universal-3-5-pro in assemblyAiTranscriber.ts.)