### PR TITLE
Bug Fix:  Don't make LLM provider request  if there is no transcript

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
 	"id": "scribe",
 	"name": "Scribe",
-	"version": "2.3.7",
+	"version": "2.3.8",
 	"minAppVersion": "0.15.0",
 	"description": "Record, transcribe, and transform voice notes into structured insights. Leverage Whisper or AssemblyAI and ChatGPT to fill in gaps, generate summaries, and visualize ideas — all seamlessly integrated within Obsidian.",
 	"author": "Mike Alicea",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "obsidian-scribe-plugin",
-	"version": "2.3.7",
+	"version": "2.3.8",
 	"description": "An Obsidian plugin for recording voice notes, transcribing the audio, and summarizing the text - All in one",
 	"main": "build/main.js",
 	"scripts": {

--- a/src/index.ts
+++ b/src/index.ts
@@ -422,6 +422,11 @@ export default class ScribePlugin extends Plugin {
       return;
     }
 
+    if (!transcript.trim()) {
+      new Notice('Scribe: ⚠️ Skipping LLM processing — transcript is empty');
+      return;
+    }
+
     const llmSummary = await this.handleTranscriptSummary(
       transcript,
       scribeOptions,

--- a/src/settings/GeneralSettingsTab.tsx
+++ b/src/settings/GeneralSettingsTab.tsx
@@ -20,6 +20,8 @@ const languagesMapping = Object.entries(LanguageDisplayNames)
 function GeneralSettingsTab() {
   const { register, settings } = useSettingsForm();
 
+  const isTranscriptionDisabled = settings.isDisableLlmTranscription;
+
   const isDateInPrefix =
     (settings.noteFilenamePrefix || '').includes('{{date}}') ||
     (settings.recordingFilenamePrefix || '').includes('{{date}}');
@@ -45,11 +47,13 @@ function GeneralSettingsTab() {
           // Inverted displayed value because initial semantics was misleading
           // Old: negative meaning (disable) => Truthy toggle state
           // New: positive meaning (enable) => Truthy toggle state
-          displayValue: (value) => !value,
+          // Forced off while transcription is disabled — there is nothing to process
+          displayValue: (value) => !value && !isTranscriptionDisabled,
           setValueAs: (value) => !value,
         })}
+        disabled={isTranscriptionDisabled}
         name="Process transcriptions with LLM"
-        description="If disabled, we will only transcribe recordings without summarization, insights etc."
+        description="If disabled, we will only transcribe recordings without summarization, insights etc. Requires transcription to be enabled."
       />
 
       <SettingsItemHeader name="Language" />

--- a/src/settings/components/SettingsControl.tsx
+++ b/src/settings/components/SettingsControl.tsx
@@ -5,6 +5,7 @@ interface SettingsToggleProps<K extends keyof ScribePluginSettings>
   extends Omit<SettingsControlProps<K>, 'children'> {
   onChange(value: ScribePluginSettings[K] & boolean): void;
   value: ScribePluginSettings[K] & boolean;
+  disabled?: boolean;
 }
 
 /**
@@ -13,11 +14,17 @@ interface SettingsToggleProps<K extends keyof ScribePluginSettings>
 export function SettingsToggle(
   props: SettingsToggleProps<keyof ScribePluginSettings>,
 ) {
-  const { id, onChange, value } = props;
+  const { id, onChange, value, disabled } = props;
   if (typeof value !== 'boolean') {
     console.error(`Can't use checkbox input for non-boolean value: ${id}`);
     return null;
   }
+
+  const handleToggle = () => {
+    if (!disabled) {
+      onChange(!value);
+    }
+  };
 
   return (
     <SettingsControl {...props}>
@@ -25,10 +32,11 @@ export function SettingsToggle(
         <input
           type="checkbox"
           checked={value}
-          onChange={() => onChange(!value)}
+          disabled={disabled}
+          onChange={handleToggle}
           onKeyDown={(e) => {
             if (e.key === 'Enter') {
-              onChange(!value);
+              handleToggle();
             }
           }}
         />


### PR DESCRIPTION
## Fix: Skip LLM processing when transcription is disabled (#104)

Fixes #104

### Problem

The "Transcribe recordings" and "Process transcriptions with LLM" settings were fully independent. With transcription **off** and processing **on**, `handleTranscription()` returned an empty string and the pipeline sent it straight to the LLM — resulting in a pointless (and paid) LLM call that generated garbage note sections.

### Changes

- **Settings UI** (`src/settings/GeneralSettingsTab.tsx`): "Process transcriptions with LLM" is now disabled and displayed as off while "Transcribe recordings" is off. The stored preference is left untouched, so re-enabling transcription restores the previous processing state. Description updated to note the dependency.
- **Toggle component** (`src/settings/components/SettingsControl.tsx`): `SettingsToggle` now supports a `disabled` prop (click and Enter-key handlers are guarded).
- **Pipeline guard** (`src/index.ts`, `handleScribeFile`): if the transcript is empty, LLM summarization is skipped with a `Scribe: ⚠️ Skipping LLM processing — transcript is empty` notice. This covers stale persisted settings, the modal inheriting the disabled-transcription flag, and any provider legitimately returning an empty transcript.

### Testing

- `npm run format:write`, `npm run lint:write`, `npm run build:prod` all pass
- Manual: with "Transcribe recordings" off, the processing toggle is off/unclickable; completing a recording shows the skip notice instead of calling the LLM. Re-enabling transcription restores the previous processing preference.