### PR TITLE
Fix: Downgrades react and removes standardized-audio-context

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
 	"id": "scribe",
 	"name": "Scribe",
-	"version": "2.3.9",
+	"version": "2.4.0",
 	"minAppVersion": "0.15.0",
 	"description": "Record, transcribe, and transform voice notes into structured insights. Leverage Whisper or AssemblyAI and ChatGPT to fill in gaps, generate summaries, and visualize ideas — all seamlessly integrated within Obsidian.",
 	"author": "Mike Alicea",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "obsidian-scribe-plugin",
-	"version": "2.3.4",
+	"version": "2.3.9",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "obsidian-scribe-plugin",
-			"version": "2.3.4",
+			"version": "2.3.9",
 			"license": "MIT",
 			"dependencies": {
 				"@anthropic-ai/sdk": "^0.111.0",
@@ -16,16 +16,15 @@
 				"langchain": "^1.5.3",
 				"mini-debounce": "^1.0.8",
 				"openai": "^6.46.0",
-				"react": "^19.2.7",
-				"react-dom": "^19.2.7",
-				"standardized-audio-context": "^25.3.77",
+				"react": "^18.3.1",
+				"react-dom": "^18.3.1",
 				"zod": "^4.4.3"
 			},
 			"devDependencies": {
 				"@biomejs/biome": "^2.5.3",
 				"@types/node": "^26.1.1",
-				"@types/react": "^19.2.17",
-				"@types/react-dom": "^19.1.3",
+				"@types/react": "^18.3.28",
+				"@types/react-dom": "^18.3.7",
 				"dotenv": "^17.4.2",
 				"esbuild": "^0.28.1",
 				"obsidian": "^1.13.1",
@@ -903,24 +902,32 @@
 				"undici-types": "~8.3.0"
 			}
 		},
+		"node_modules/@types/prop-types": {
+			"version": "15.7.15",
+			"resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.15.tgz",
+			"integrity": "sha512-F6bEyamV9jKGAFBEmlQnesRPGOQqS2+Uwi0Em15xenOxHaf2hv6L8YCVn3rPdPJOiJfPiCnLIRyvwVaqMY3MIw==",
+			"dev": true,
+			"license": "MIT"
+		},
 		"node_modules/@types/react": {
-			"version": "19.2.17",
-			"resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.17.tgz",
-			"integrity": "sha512-MXfmqaVPEVgkBT/aY0aGCkRWWtByiYQXo3xdQ8r5RzuFrPiRn8Gar2tQdXSUQ2GKV3bkXckek89V8wQBY2Q/Aw==",
+			"version": "18.3.31",
+			"resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.31.tgz",
+			"integrity": "sha512-vfEqpXTvwT91yhmwdfouStN2hSKwTvyRs8qpLfADyrq/kxDw0hZM7Wk9Ug1FELj8hIby+S/+kQCSRFF32nv2Qw==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
+				"@types/prop-types": "*",
 				"csstype": "^3.2.2"
 			}
 		},
 		"node_modules/@types/react-dom": {
-			"version": "19.2.3",
-			"resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-19.2.3.tgz",
-			"integrity": "sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==",
+			"version": "18.3.7",
+			"resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-18.3.7.tgz",
+			"integrity": "sha512-MEe3UeoENYVFXzoXEWsvcpg6ZvlrFNlOQ7EOsvhI3CfAXwzPfO8Qwuxd40nepsYKqyyVQnTdEfv68q91yLcKrQ==",
 			"dev": true,
 			"license": "MIT",
 			"peerDependencies": {
-				"@types/react": "^19.2.0"
+				"@types/react": "^18.0.0"
 			}
 		},
 		"node_modules/@types/tern": {
@@ -1291,19 +1298,6 @@
 				"node": ">=18"
 			}
 		},
-		"node_modules/automation-events": {
-			"version": "7.1.15",
-			"resolved": "https://registry.npmjs.org/automation-events/-/automation-events-7.1.15.tgz",
-			"integrity": "sha512-NsHJlve3twcgs8IyP4iEYph7Fzpnh6klN7G5LahwvypakBjFbsiGHJxrqTmeHKREdu/Tx6oZboqNI0tD4MnFlA==",
-			"license": "MIT",
-			"dependencies": {
-				"@babel/runtime": "^7.28.6",
-				"tslib": "^2.8.1"
-			},
-			"engines": {
-				"node": ">=18.2.0"
-			}
-		},
 		"node_modules/base64-js": {
 			"version": "1.5.1",
 			"resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
@@ -1494,6 +1488,12 @@
 				"base64-js": "^1.5.1"
 			}
 		},
+		"node_modules/js-tokens": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
+			"integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
+			"license": "MIT"
+		},
 		"node_modules/json-schema-to-ts": {
 			"version": "3.1.1",
 			"resolved": "https://registry.npmjs.org/json-schema-to-ts/-/json-schema-to-ts-3.1.1.tgz",
@@ -1557,6 +1557,18 @@
 				"openai": {
 					"optional": true
 				}
+			}
+		},
+		"node_modules/loose-envify": {
+			"version": "1.4.0",
+			"resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
+			"integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
+			"license": "MIT",
+			"dependencies": {
+				"js-tokens": "^3.0.0 || ^4.0.0"
+			},
+			"bin": {
+				"loose-envify": "cli.js"
 			}
 		},
 		"node_modules/mini-debounce": {
@@ -1682,31 +1694,38 @@
 			}
 		},
 		"node_modules/react": {
-			"version": "19.2.7",
-			"resolved": "https://registry.npmjs.org/react/-/react-19.2.7.tgz",
-			"integrity": "sha512-HNe9WslTbXmFK8o8cmwgAeJFSBvt1bPdHCVKtaaV+WlAN36mpT4hcRpwbf3fY56ar2oIXzsBpOAiIRHAdY0OlQ==",
+			"version": "18.3.1",
+			"resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
+			"integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
 			"license": "MIT",
+			"dependencies": {
+				"loose-envify": "^1.1.0"
+			},
 			"engines": {
 				"node": ">=0.10.0"
 			}
 		},
 		"node_modules/react-dom": {
-			"version": "19.2.7",
-			"resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.7.tgz",
-			"integrity": "sha512-t0BRVXvbiE/o20Hfw669rLbMCDWtYZLvmJigy2f0MxsXF+71pxhR3xOkspmsO8h3ZlNzyibAmtCa3l4lYKk6gQ==",
+			"version": "18.3.1",
+			"resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.3.1.tgz",
+			"integrity": "sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==",
 			"license": "MIT",
 			"dependencies": {
-				"scheduler": "^0.27.0"
+				"loose-envify": "^1.1.0",
+				"scheduler": "^0.23.2"
 			},
 			"peerDependencies": {
-				"react": "^19.2.7"
+				"react": "^18.3.1"
 			}
 		},
 		"node_modules/scheduler": {
-			"version": "0.27.0",
-			"resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.27.0.tgz",
-			"integrity": "sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==",
-			"license": "MIT"
+			"version": "0.23.2",
+			"resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.23.2.tgz",
+			"integrity": "sha512-UOShsPwz7NrMUqhR6t0hWjFduvOzbtv7toDH1/hIrfRNIDBnnBWd0CwJTGvTpngVlmwGCdP9/Zl/tVrDqcuYzQ==",
+			"license": "MIT",
+			"dependencies": {
+				"loose-envify": "^1.1.0"
+			}
 		},
 		"node_modules/semver": {
 			"version": "7.7.4",
@@ -1725,17 +1744,6 @@
 			"resolved": "https://registry.npmjs.org/simple-wcswidth/-/simple-wcswidth-1.1.2.tgz",
 			"integrity": "sha512-j7piyCjAeTDSjzTSQ7DokZtMNwNlEAyxqSZeCS+CXH7fJ4jx3FuJ/mTW3mE+6JLs4VJBbcll0Kjn+KXI5t21Iw==",
 			"license": "MIT"
-		},
-		"node_modules/standardized-audio-context": {
-			"version": "25.3.77",
-			"resolved": "https://registry.npmjs.org/standardized-audio-context/-/standardized-audio-context-25.3.77.tgz",
-			"integrity": "sha512-Ki9zNz6pKcC5Pi+QPjPyVsD9GwJIJWgryji0XL9cAJXMGyn+dPOf6Qik1AHei0+UNVcc4BOCa0hWLBzlwqsW/A==",
-			"license": "MIT",
-			"dependencies": {
-				"@babel/runtime": "^7.25.6",
-				"automation-events": "^7.0.9",
-				"tslib": "^2.7.0"
-			}
 		},
 		"node_modules/standardwebhooks": {
 			"version": "1.0.0",
@@ -1777,6 +1785,7 @@
 			"version": "2.8.1",
 			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
 			"integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+			"dev": true,
 			"license": "0BSD"
 		},
 		"node_modules/typescript": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "obsidian-scribe-plugin",
-	"version": "2.3.9",
+	"version": "2.4.0",
 	"description": "An Obsidian plugin for recording voice notes, transcribing the audio, and summarizing the text - All in one",
 	"main": "build/main.js",
 	"scripts": {
@@ -20,8 +20,8 @@
 	"devDependencies": {
 		"@biomejs/biome": "^2.5.3",
 		"@types/node": "^26.1.1",
-		"@types/react": "^19.2.17",
-		"@types/react-dom": "^19.1.3",
+		"@types/react": "^18.3.28",
+		"@types/react-dom": "^18.3.7",
 		"dotenv": "^17.4.2",
 		"esbuild": "^0.28.1",
 		"obsidian": "^1.13.1",
@@ -36,9 +36,8 @@
 		"langchain": "^1.5.3",
 		"mini-debounce": "^1.0.8",
 		"openai": "^6.46.0",
-		"react": "^19.2.7",
-		"react-dom": "^19.2.7",
-		"standardized-audio-context": "^25.3.77",
+		"react": "^18.3.1",
+		"react-dom": "^18.3.1",
 		"zod": "^4.4.3"
 	}
 }

--- a/src/util/audioDataToChunkedFiles.ts
+++ b/src/util/audioDataToChunkedFiles.ts
@@ -6,7 +6,15 @@
 
 import { toFile } from 'openai';
 import type { Uploadable } from 'openai/uploads';
-import { AudioContext, type IAudioBuffer } from 'standardized-audio-context';
+
+// Older iOS WebViews only expose the prefixed constructor
+function getAudioContextConstructor(): typeof AudioContext {
+  return (
+    window.AudioContext ||
+    (window as unknown as { webkitAudioContext: typeof AudioContext })
+      .webkitAudioContext
+  );
+}
 
 /**
  * Given an input file, converts it to mono, splits that mono audio into chunks
@@ -17,7 +25,8 @@ export default async function audioDataToChunkedFiles(
   maxSize: number,
 ): Promise<Uploadable[]> {
   try {
-    const audioContext = new AudioContext();
+    const AudioContextConstructor = getAudioContextConstructor();
+    const audioContext = new AudioContextConstructor();
 
     // fallback for iOS / WebKit decodeAudioData limits (> ~30s)
     let sourceBuffer: AudioBuffer | undefined;
@@ -98,7 +107,7 @@ function audioBufferToMono(
 }
 
 // Look, I'm not gonna pretend ChatGPT didn't write this
-export function audioBufferToWav(buffer: IAudioBuffer) {
+export function audioBufferToWav(buffer: AudioBuffer) {
   const numOfChannels = buffer.numberOfChannels;
   const sampleRate = buffer.sampleRate;
   const length = buffer.length * numOfChannels * 2; // 16-bit PCM data


### PR DESCRIPTION
# Fix error that has been preventing release
Downgrades React and removes `standardized-audio-context` library in hopes that it fixes the error that Obsidian was surfacing
```
Error
Found 4 dynamic <script> element creations
Dynamically injecting script elements can load and execute arbitrary external code.
```

## v2.4.0

### Fixed Obsidian plugin review blocker: dynamic `<script>` element creations

The automated Obsidian plugin review flagged 4 dynamic `<script>` element creations in the bundled `main.js`. All 4 came from third-party dependencies — none from Scribe's own code — and have been fully removed from the bundle.

#### Changes

- **Downgraded `react` / `react-dom` from v19 to v18.3.1** — React 19 introduced "hoistable scripts" support (`ReactDOM.preinit`), which ships `createElement("script")` code paths in the production bundle even though Scribe never uses them. Scribe only uses standard hooks and `createRoot`, all fully supported in React 18.3, so this is a drop-in downgrade with no functional changes.
- **Removed the `standardized-audio-context` dependency** — its AudioWorklet polyfill loads code via a Blob-URL `<script>` tag. Scribe only used it for `AudioContext` / `decodeAudioData` / `createBuffer` during audio chunking, all of which are natively available in Obsidian's desktop and mobile environments. The audio chunking pipeline (`audioDataToChunkedFiles`) now uses the native Web Audio API directly, with a `webkitAudioContext` fallback for older iOS WebViews.

#### Verification

- Production bundle now contains **0** dynamic script element creations (previously 4)
- Also scanned the bundle for `eval(`, `new Function(`, and `document.write` — all clean
- Typecheck, lint, and production build all pass

No user-facing behavior changes — recording, transcription, and summarization work exactly as before.

A note on where verification stands: I confirmed the bundle is clean via static checks and the full typecheck/build, but the headless-Chrome runtime test of the audio chunking path was blocked by the sandbox (Chrome can't launch from this session). Since decodeAudioData/createBuffer have identical signatures between the removed library and the native API, risk is low — but I'd recommend one manual smoke test: record a short clip with OpenAI transcription selected before publishing the release, since that's the path that exercises the refactored chunking code.